### PR TITLE
feat: selectable AI tools and fix OpenCode provider config

### DIFF
--- a/internal/opencode/settings.go
+++ b/internal/opencode/settings.go
@@ -9,24 +9,24 @@ import (
 )
 
 const (
-	// ProviderKey is the provider key used in .opencode.json for yokai endpoints.
+	// ProviderKey is the provider key used in opencode.json for yokai endpoints.
 	ProviderKey = "yokai"
-	// ModelPrefix is the prefix for local model references in OpenCode.
-	ModelPrefix = "local."
+	// NPMPackage is the AI SDK package for OpenAI-compatible providers.
+	NPMPackage = "@ai-sdk/openai-compatible"
+	// ProviderDisplayName is the display name shown in OpenCode's UI.
+	ProviderDisplayName = "Yokai"
 )
 
 // Endpoint represents an OpenAI-compatible model endpoint for OpenCode.
 type Endpoint struct {
 	BaseURL   string // e.g. "http://192.168.1.100:8000/v1"
-	ModelID   string // e.g. "Meta-Llama-3.1-70B-Instruct"
+	ModelID   string // e.g. "meta-llama/Llama-3.1-70B-Instruct"
 	ModelName string // e.g. "Llama 3.1 70B (yokai)"
 }
 
-// DetectConfigPath finds the OpenCode .opencode.json config path.
-// Checks in order: $XDG_CONFIG_HOME/opencode/.opencode.json, ~/.opencode.json
-// Returns the user-level config path (does not check project-local .opencode.json).
+// DetectConfigPath finds the OpenCode opencode.json config path.
+// Checks: $XDG_CONFIG_HOME/opencode/opencode.json, ~/.config/opencode/opencode.json
 func DetectConfigPath() (string, error) {
-	// Check XDG config first
 	configDir := os.Getenv("XDG_CONFIG_HOME")
 	if configDir == "" {
 		home, err := os.UserHomeDir()
@@ -36,29 +36,12 @@ func DetectConfigPath() (string, error) {
 		configDir = filepath.Join(home, ".config")
 	}
 
-	xdgPath := filepath.Join(configDir, "opencode", ".opencode.json")
-	if _, err := os.Stat(xdgPath); err == nil {
-		return xdgPath, nil
-	}
-
-	// Fallback to ~/.opencode.json
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine home directory: %w", err)
-	}
-
-	homePath := filepath.Join(home, ".opencode.json")
-	if _, err := os.Stat(homePath); err == nil {
-		return homePath, nil
-	}
-
-	// Default to XDG path for creation
-	return xdgPath, nil
+	return filepath.Join(configDir, "opencode", "opencode.json"), nil
 }
 
-// AddEndpoints reads the OpenCode config and adds yokai model endpoints.
-// It sets LOCAL_ENDPOINT to the first endpoint's base URL and configures
-// the coder agent model. Creates a backup before modifying.
+// AddEndpoints reads the OpenCode config and adds a yokai provider with models.
+// Uses the OpenCode custom provider format with @ai-sdk/openai-compatible.
+// Creates a backup before modifying.
 func AddEndpoints(endpoints []Endpoint) error {
 	path, err := DetectConfigPath()
 	if err != nil {
@@ -75,7 +58,9 @@ func AddEndpointsToFile(path string, endpoints []Endpoint) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			cfg = make(map[string]interface{})
+			cfg = map[string]interface{}{
+				"$schema": "https://opencode.ai/config.json",
+			}
 		} else {
 			return fmt.Errorf("reading config: %w", err)
 		}
@@ -97,46 +82,33 @@ func AddEndpointsToFile(path string, endpoints []Endpoint) error {
 		return fmt.Errorf("no endpoints to add")
 	}
 
-	// Set up the yokai provider under "providers"
-	providers, _ := cfg["providers"].(map[string]interface{})
-	if providers == nil {
-		providers = make(map[string]interface{})
+	// Get or create provider section
+	provider, _ := cfg["provider"].(map[string]interface{})
+	if provider == nil {
+		provider = make(map[string]interface{})
 	}
 
-	providers[ProviderKey] = map[string]interface{}{
-		"apiKey":   "none",
-		"disabled": false,
-	}
-	cfg["providers"] = providers
-
-	// Set the first endpoint's model as the coder agent model.
-	// OpenCode uses LOCAL_ENDPOINT env var for the base URL, but we can also
-	// configure the model reference directly.
-	agents, _ := cfg["agents"].(map[string]interface{})
-	if agents == nil {
-		agents = make(map[string]interface{})
-	}
-
-	coder, _ := agents["coder"].(map[string]interface{})
-	if coder == nil {
-		coder = make(map[string]interface{})
-	}
-
-	// Use the first endpoint's model as the coder model
-	coder["model"] = ModelPrefix + endpoints[0].ModelID
-	agents["coder"] = coder
-	cfg["agents"] = agents
-
-	// Store yokai endpoint metadata as a custom section for tracking
-	var yokaiModels []interface{}
+	// Build models map from endpoints
+	models := make(map[string]interface{})
 	for _, ep := range endpoints {
-		yokaiModels = append(yokaiModels, map[string]interface{}{
-			"id":       ep.ModelID,
-			"name":     ep.ModelName,
-			"base_url": ep.BaseURL,
-		})
+		models[ep.ModelID] = map[string]interface{}{
+			"name": ep.ModelName,
+		}
 	}
-	cfg["yokai_endpoints"] = yokaiModels
+
+	// Use the first endpoint's base URL for the provider
+	// (all yokai endpoints from a single fleet typically share the same base URL pattern)
+	provider[ProviderKey] = map[string]interface{}{
+		"npm":  NPMPackage,
+		"name": ProviderDisplayName,
+		"options": map[string]interface{}{
+			"baseURL": endpoints[0].BaseURL,
+			"apiKey":  "none",
+		},
+		"models": models,
+	}
+
+	cfg["provider"] = provider
 
 	// Write back
 	return writeConfig(path, cfg)
@@ -154,32 +126,16 @@ func RemoveEndpoints(configPath string) error {
 		return err
 	}
 
-	// Remove yokai provider
-	if providers, ok := cfg["providers"].(map[string]interface{}); ok {
-		delete(providers, ProviderKey)
-		cfg["providers"] = providers
+	// Remove yokai provider from "provider" section
+	if provider, ok := cfg["provider"].(map[string]interface{}); ok {
+		delete(provider, ProviderKey)
+		cfg["provider"] = provider
 	}
-
-	// Reset coder model if it points to a yokai/local model
-	if agents, ok := cfg["agents"].(map[string]interface{}); ok {
-		if coder, ok := agents["coder"].(map[string]interface{}); ok {
-			if model, ok := coder["model"].(string); ok {
-				if strings.HasPrefix(model, ModelPrefix) {
-					delete(coder, "model")
-				}
-			}
-			agents["coder"] = coder
-		}
-		cfg["agents"] = agents
-	}
-
-	// Remove yokai endpoint tracking
-	delete(cfg, "yokai_endpoints")
 
 	return writeConfig(configPath, cfg)
 }
 
-// HasYokaiEndpoints checks if the config file has yokai endpoints configured.
+// HasYokaiEndpoints checks if the config file has a yokai provider configured.
 func HasYokaiEndpoints(configPath string) bool {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
@@ -191,6 +147,13 @@ func HasYokaiEndpoints(configPath string) bool {
 		return false
 	}
 
+	if provider, ok := cfg["provider"].(map[string]interface{}); ok {
+		if _, ok := provider[ProviderKey]; ok {
+			return true
+		}
+	}
+
+	// Also check legacy "providers" key
 	if providers, ok := cfg["providers"].(map[string]interface{}); ok {
 		if _, ok := providers[ProviderKey]; ok {
 			return true
@@ -198,6 +161,59 @@ func HasYokaiEndpoints(configPath string) bool {
 	}
 
 	return false
+}
+
+// MigrateLegacyConfig checks for the old .opencode.json format and removes
+// legacy yokai entries (providers, agents, yokai_endpoints keys).
+func MigrateLegacyConfig(configPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil // File doesn't exist, nothing to migrate
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+
+	changed := false
+
+	// Remove legacy "providers" yokai entry
+	if providers, ok := cfg["providers"].(map[string]interface{}); ok {
+		if _, ok := providers[ProviderKey]; ok {
+			delete(providers, ProviderKey)
+			if len(providers) == 0 {
+				delete(cfg, "providers")
+			} else {
+				cfg["providers"] = providers
+			}
+			changed = true
+		}
+	}
+
+	// Remove legacy "agents" coder model if it uses local. prefix
+	if agents, ok := cfg["agents"].(map[string]interface{}); ok {
+		if coder, ok := agents["coder"].(map[string]interface{}); ok {
+			if model, ok := coder["model"].(string); ok {
+				if strings.HasPrefix(model, "local.") {
+					delete(coder, "model")
+					changed = true
+				}
+			}
+		}
+	}
+
+	// Remove legacy yokai_endpoints tracking
+	if _, ok := cfg["yokai_endpoints"]; ok {
+		delete(cfg, "yokai_endpoints")
+		changed = true
+	}
+
+	if changed {
+		return writeConfig(configPath, cfg)
+	}
+
+	return nil
 }
 
 func writeConfig(path string, cfg map[string]interface{}) error {

--- a/internal/opencode/settings_test.go
+++ b/internal/opencode/settings_test.go
@@ -20,9 +20,9 @@ func TestDetectConfigPath(t *testing.T) {
 		t.Error("path should not be empty")
 	}
 
-	// Should end with .opencode.json
-	if !strings.HasSuffix(path, ".opencode.json") {
-		t.Errorf("path should end with .opencode.json, got: %s", path)
+	// Should end with opencode.json (no dot prefix)
+	if !strings.HasSuffix(path, "opencode/opencode.json") {
+		t.Errorf("path should end with opencode/opencode.json, got: %s", path)
 	}
 }
 
@@ -30,23 +30,14 @@ func TestDetectConfigPathWithXDG(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tempDir)
 
-	// Create the XDG config file
-	xdgDir := filepath.Join(tempDir, "opencode")
-	if err := os.MkdirAll(xdgDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	xdgPath := filepath.Join(xdgDir, ".opencode.json")
-	if err := os.WriteFile(xdgPath, []byte("{}"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
 	path, err := DetectConfigPath()
 	if err != nil {
 		t.Fatalf("DetectConfigPath with XDG failed: %v", err)
 	}
 
-	if path != xdgPath {
-		t.Errorf("expected path %s, got %s", xdgPath, path)
+	expected := filepath.Join(tempDir, "opencode", "opencode.json")
+	if path != expected {
+		t.Errorf("expected path %s, got %s", expected, path)
 	}
 }
 
@@ -54,12 +45,12 @@ func TestAddEndpointsToNewFile(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".opencode.json")
+	configPath := filepath.Join(tempDir, "opencode.json")
 
 	endpoints := []Endpoint{
 		{
 			BaseURL:   "http://192.168.1.100:8000/v1",
-			ModelID:   "Meta-Llama-3.1-70B-Instruct",
+			ModelID:   "meta-llama/Llama-3.1-70B-Instruct",
 			ModelName: "Llama 3.1 70B (yokai)",
 		},
 	}
@@ -74,36 +65,40 @@ func TestAddEndpointsToNewFile(t *testing.T) {
 		t.Fatalf("failed to read config: %v", err)
 	}
 
-	// Verify provider was added
-	providers := cfg["providers"].(map[string]interface{})
-	yokai, ok := providers[ProviderKey].(map[string]interface{})
+	// Verify $schema is set
+	if cfg["$schema"] != "https://opencode.ai/config.json" {
+		t.Error("$schema should be set")
+	}
+
+	// Verify provider was added with correct format
+	provider := cfg["provider"].(map[string]interface{})
+	yokai, ok := provider[ProviderKey].(map[string]interface{})
 	if !ok {
 		t.Fatal("yokai provider should exist")
 	}
-	if yokai["disabled"] != false {
-		t.Error("yokai provider should not be disabled")
+
+	if yokai["npm"] != NPMPackage {
+		t.Errorf("expected npm %s, got %v", NPMPackage, yokai["npm"])
 	}
 
-	// Verify agent model was set
-	agents := cfg["agents"].(map[string]interface{})
-	coder := agents["coder"].(map[string]interface{})
-	model := coder["model"].(string)
-	if model != "local.Meta-Llama-3.1-70B-Instruct" {
-		t.Errorf("expected model 'local.Meta-Llama-3.1-70B-Instruct', got '%s'", model)
+	if yokai["name"] != ProviderDisplayName {
+		t.Errorf("expected name %s, got %v", ProviderDisplayName, yokai["name"])
 	}
 
-	// Verify yokai_endpoints tracking
-	yokaiEndpoints := cfg["yokai_endpoints"].([]interface{})
-	if len(yokaiEndpoints) != 1 {
-		t.Errorf("expected 1 yokai endpoint, got %d", len(yokaiEndpoints))
+	// Verify options
+	options := yokai["options"].(map[string]interface{})
+	if options["baseURL"] != "http://192.168.1.100:8000/v1" {
+		t.Errorf("unexpected baseURL: %v", options["baseURL"])
 	}
 
-	ep := yokaiEndpoints[0].(map[string]interface{})
-	if ep["id"] != "Meta-Llama-3.1-70B-Instruct" {
-		t.Errorf("endpoint ID mismatch: %v", ep["id"])
+	// Verify models
+	models := yokai["models"].(map[string]interface{})
+	model, ok := models["meta-llama/Llama-3.1-70B-Instruct"].(map[string]interface{})
+	if !ok {
+		t.Fatal("model should exist in models map")
 	}
-	if ep["base_url"] != "http://192.168.1.100:8000/v1" {
-		t.Errorf("endpoint base_url mismatch: %v", ep["base_url"])
+	if model["name"] != "Llama 3.1 70B (yokai)" {
+		t.Errorf("unexpected model name: %v", model["name"])
 	}
 }
 
@@ -111,21 +106,18 @@ func TestAddEndpointsToExistingFile(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".opencode.json")
+	configPath := filepath.Join(tempDir, "opencode.json")
 
-	// Create existing config
+	// Create existing config with schema and theme
 	existingCfg := map[string]interface{}{
-		"debug": true,
-		"providers": map[string]interface{}{
+		"$schema":    "https://opencode.ai/config.json",
+		"theme":      "system",
+		"autoupdate": false,
+		"provider": map[string]interface{}{
 			"anthropic": map[string]interface{}{
-				"apiKey":   "sk-existing",
-				"disabled": false,
-			},
-		},
-		"agents": map[string]interface{}{
-			"coder": map[string]interface{}{
-				"model":     "claude-3.7-sonnet",
-				"maxTokens": 5000,
+				"options": map[string]interface{}{
+					"baseURL": "https://api.anthropic.com/v1",
+				},
 			},
 		},
 	}
@@ -136,12 +128,12 @@ func TestAddEndpointsToExistingFile(t *testing.T) {
 	endpoints := []Endpoint{
 		{
 			BaseURL:   "http://192.168.1.100:8000/v1",
-			ModelID:   "Meta-Llama-3.1-70B-Instruct",
+			ModelID:   "meta-llama/Llama-3.1-70B-Instruct",
 			ModelName: "Llama 3.1 70B (yokai)",
 		},
 		{
-			BaseURL:   "http://192.168.1.101:8000/v1",
-			ModelID:   "Qwen2.5-Coder-32B",
+			BaseURL:   "http://192.168.1.100:8000/v1",
+			ModelID:   "Qwen/Qwen2.5-Coder-32B",
 			ModelName: "Qwen 2.5 Coder (yokai)",
 		},
 	}
@@ -162,37 +154,31 @@ func TestAddEndpointsToExistingFile(t *testing.T) {
 	}
 
 	// Verify existing settings preserved
-	if cfg["debug"] != true {
-		t.Error("existing debug setting should be preserved")
+	if cfg["theme"] != "system" {
+		t.Error("existing theme setting should be preserved")
+	}
+	if cfg["autoupdate"] != false {
+		t.Error("existing autoupdate setting should be preserved")
 	}
 
 	// Verify existing provider preserved
-	providers := cfg["providers"].(map[string]interface{})
-	if _, ok := providers["anthropic"]; !ok {
+	provider := cfg["provider"].(map[string]interface{})
+	if _, ok := provider["anthropic"]; !ok {
 		t.Error("existing anthropic provider should be preserved")
 	}
 
-	// Verify yokai provider added
-	if _, ok := providers[ProviderKey]; !ok {
-		t.Error("yokai provider should be added")
+	// Verify yokai provider added with both models
+	yokai := provider[ProviderKey].(map[string]interface{})
+	models := yokai["models"].(map[string]interface{})
+	if len(models) != 2 {
+		t.Errorf("expected 2 models, got %d", len(models))
 	}
 
-	// Verify existing agent maxTokens preserved
-	agents := cfg["agents"].(map[string]interface{})
-	coder := agents["coder"].(map[string]interface{})
-	if coder["maxTokens"].(float64) != 5000 {
-		t.Error("existing maxTokens should be preserved")
+	if _, ok := models["meta-llama/Llama-3.1-70B-Instruct"]; !ok {
+		t.Error("first model should exist")
 	}
-
-	// Verify model was updated to first yokai endpoint
-	if coder["model"] != "local.Meta-Llama-3.1-70B-Instruct" {
-		t.Errorf("model should be updated, got: %v", coder["model"])
-	}
-
-	// Verify both endpoints tracked
-	yokaiEndpoints := cfg["yokai_endpoints"].([]interface{})
-	if len(yokaiEndpoints) != 2 {
-		t.Errorf("expected 2 yokai endpoints, got %d", len(yokaiEndpoints))
+	if _, ok := models["Qwen/Qwen2.5-Coder-32B"]; !ok {
+		t.Error("second model should exist")
 	}
 }
 
@@ -200,7 +186,7 @@ func TestAddEndpointsNoEndpoints(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".opencode.json")
+	configPath := filepath.Join(tempDir, "opencode.json")
 
 	err := AddEndpointsToFile(configPath, nil)
 	if err == nil {
@@ -212,31 +198,28 @@ func TestRemoveEndpoints(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".opencode.json")
+	configPath := filepath.Join(tempDir, "opencode.json")
 
 	// Create config with yokai + other settings
 	cfg := map[string]interface{}{
-		"debug": true,
-		"providers": map[string]interface{}{
+		"$schema": "https://opencode.ai/config.json",
+		"theme":   "system",
+		"provider": map[string]interface{}{
 			"anthropic": map[string]interface{}{
-				"apiKey": "sk-existing",
+				"options": map[string]interface{}{"baseURL": "https://api.anthropic.com/v1"},
 			},
 			ProviderKey: map[string]interface{}{
-				"apiKey":   "none",
-				"disabled": false,
-			},
-		},
-		"agents": map[string]interface{}{
-			"coder": map[string]interface{}{
-				"model":     "local.Meta-Llama-3.1-70B-Instruct",
-				"maxTokens": 5000,
-			},
-		},
-		"yokai_endpoints": []interface{}{
-			map[string]interface{}{
-				"id":       "Meta-Llama-3.1-70B-Instruct",
-				"name":     "Llama 3.1 70B (yokai)",
-				"base_url": "http://192.168.1.100:8000/v1",
+				"npm":  NPMPackage,
+				"name": ProviderDisplayName,
+				"options": map[string]interface{}{
+					"baseURL": "http://192.168.1.100:8000/v1",
+					"apiKey":  "none",
+				},
+				"models": map[string]interface{}{
+					"meta-llama/Llama-3.1-70B-Instruct": map[string]interface{}{
+						"name": "Llama 3.1 70B (yokai)",
+					},
+				},
 			},
 		},
 	}
@@ -255,36 +238,19 @@ func TestRemoveEndpoints(t *testing.T) {
 	}
 
 	// Verify non-yokai settings preserved
-	if updated["debug"] != true {
-		t.Error("debug setting should be preserved")
+	if updated["theme"] != "system" {
+		t.Error("theme setting should be preserved")
 	}
 
 	// Verify anthropic provider preserved
-	providers := updated["providers"].(map[string]interface{})
-	if _, ok := providers["anthropic"]; !ok {
+	provider := updated["provider"].(map[string]interface{})
+	if _, ok := provider["anthropic"]; !ok {
 		t.Error("anthropic provider should be preserved")
 	}
 
 	// Verify yokai provider removed
-	if _, ok := providers[ProviderKey]; ok {
+	if _, ok := provider[ProviderKey]; ok {
 		t.Error("yokai provider should be removed")
-	}
-
-	// Verify local model reference removed
-	agents := updated["agents"].(map[string]interface{})
-	coder := agents["coder"].(map[string]interface{})
-	if _, ok := coder["model"]; ok {
-		t.Error("local model reference should be removed")
-	}
-
-	// Verify maxTokens preserved
-	if coder["maxTokens"].(float64) != 5000 {
-		t.Error("maxTokens should be preserved")
-	}
-
-	// Verify yokai_endpoints removed
-	if _, ok := updated["yokai_endpoints"]; ok {
-		t.Error("yokai_endpoints should be removed")
 	}
 }
 
@@ -292,9 +258,12 @@ func TestBackupCreation(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".opencode.json")
+	configPath := filepath.Join(tempDir, "opencode.json")
 
-	originalCfg := map[string]interface{}{"debug": true}
+	originalCfg := map[string]interface{}{
+		"$schema": "https://opencode.ai/config.json",
+		"theme":   "system",
+	}
 	if err := writeTestConfig(configPath, originalCfg); err != nil {
 		t.Fatal(err)
 	}
@@ -332,11 +301,14 @@ func TestHasYokaiEndpoints(t *testing.T) {
 
 	tempDir := t.TempDir()
 
-	// Test with yokai provider
+	// Test with yokai provider (new format)
 	withYokai := filepath.Join(tempDir, "with-yokai.json")
 	if err := writeTestConfig(withYokai, map[string]interface{}{
-		"providers": map[string]interface{}{
-			ProviderKey: map[string]interface{}{"apiKey": "none"},
+		"provider": map[string]interface{}{
+			ProviderKey: map[string]interface{}{
+				"npm":  NPMPackage,
+				"name": ProviderDisplayName,
+			},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -346,11 +318,25 @@ func TestHasYokaiEndpoints(t *testing.T) {
 		t.Error("should detect yokai endpoints")
 	}
 
+	// Test with legacy format (providers plural)
+	withLegacy := filepath.Join(tempDir, "with-legacy.json")
+	if err := writeTestConfig(withLegacy, map[string]interface{}{
+		"providers": map[string]interface{}{
+			ProviderKey: map[string]interface{}{"apiKey": "none"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasYokaiEndpoints(withLegacy) {
+		t.Error("should detect yokai endpoints in legacy format")
+	}
+
 	// Test without yokai provider
 	withoutYokai := filepath.Join(tempDir, "without-yokai.json")
 	if err := writeTestConfig(withoutYokai, map[string]interface{}{
-		"providers": map[string]interface{}{
-			"anthropic": map[string]interface{}{"apiKey": "sk-test"},
+		"provider": map[string]interface{}{
+			"anthropic": map[string]interface{}{"options": map[string]interface{}{}},
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -363,6 +349,74 @@ func TestHasYokaiEndpoints(t *testing.T) {
 	// Test with missing file
 	if HasYokaiEndpoints(filepath.Join(tempDir, "nonexistent.json")) {
 		t.Error("should not detect yokai endpoints for missing file")
+	}
+}
+
+func TestMigrateLegacyConfig(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "opencode.json")
+
+	// Create legacy config
+	legacyCfg := map[string]interface{}{
+		"providers": map[string]interface{}{
+			"anthropic": map[string]interface{}{"apiKey": "sk-test"},
+			ProviderKey: map[string]interface{}{
+				"apiKey":   "none",
+				"disabled": false,
+			},
+		},
+		"agents": map[string]interface{}{
+			"coder": map[string]interface{}{
+				"model":     "local.meta-llama/Llama-3.1-70B-Instruct",
+				"maxTokens": 5000,
+			},
+		},
+		"yokai_endpoints": []interface{}{
+			map[string]interface{}{
+				"id":       "meta-llama/Llama-3.1-70B-Instruct",
+				"base_url": "http://192.168.1.100:8000/v1",
+			},
+		},
+	}
+	if err := writeTestConfig(configPath, legacyCfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateLegacyConfig(configPath); err != nil {
+		t.Fatalf("MigrateLegacyConfig failed: %v", err)
+	}
+
+	cfg, err := readConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify yokai provider removed from legacy "providers"
+	providers := cfg["providers"].(map[string]interface{})
+	if _, ok := providers[ProviderKey]; ok {
+		t.Error("yokai should be removed from legacy providers")
+	}
+	// Anthropic should be preserved
+	if _, ok := providers["anthropic"]; !ok {
+		t.Error("anthropic should be preserved")
+	}
+
+	// Verify local model reference removed from agents
+	agents := cfg["agents"].(map[string]interface{})
+	coder := agents["coder"].(map[string]interface{})
+	if _, ok := coder["model"]; ok {
+		t.Error("local model reference should be removed")
+	}
+	// maxTokens preserved
+	if coder["maxTokens"].(float64) != 5000 {
+		t.Error("maxTokens should be preserved")
+	}
+
+	// Verify yokai_endpoints removed
+	if _, ok := cfg["yokai_endpoints"]; ok {
+		t.Error("yokai_endpoints tracking should be removed")
 	}
 }
 

--- a/internal/tui/views/aitools.go
+++ b/internal/tui/views/aitools.go
@@ -22,19 +22,31 @@ const (
 	atsError
 )
 
-// toolResult holds the per-tool success/failure from auto-configure.
+// toolEntry represents a configurable AI tool with its selection state.
+type toolEntry struct {
+	name     string
+	selected bool
+}
+
+// toolResult holds the per-tool success/failure from configuration.
 type toolResult struct {
 	name string
 	ok   bool
 	err  string
 }
 
-// AITools shows OpenAI-compatible endpoints and auto-configures AI coding tools.
+// AITools shows OpenAI-compatible endpoints and lets the user select
+// which AI coding tools to configure.
 type AITools struct {
 	cfg     *config.Config
 	version string
 	state   aiToolsState
 	err     string
+
+	// Tool selection
+	tools  []toolEntry
+	cursor int
+
 	results []toolResult
 	width   int
 	height  int
@@ -45,12 +57,17 @@ type aiToolsConfigMsg struct {
 	err     error // overall error (e.g., no services)
 }
 
-// NewAITools creates the unified AI tools configuration view.
+// NewAITools creates the AI tools configuration view.
 func NewAITools(cfg *config.Config, version string) *AITools {
 	return &AITools{
 		cfg:     cfg,
 		version: version,
 		state:   atsListing,
+		tools: []toolEntry{
+			{name: "VS Code Copilot", selected: true},
+			{name: "OpenCode", selected: true},
+			{name: "OpenClaw", selected: true},
+		},
 	}
 }
 
@@ -74,27 +91,77 @@ func (a *AITools) Update(msg tea.Msg) (View, tea.Cmd) {
 		}
 
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "a":
-			if a.state == atsListing {
-				a.state = atsConfiguring
-				return a, a.autoConfigure()
-			}
-		case "esc":
-			return a, PopView()
-		case "enter":
-			if a.state == atsDone || a.state == atsError {
+		switch a.state {
+		case atsListing:
+			return a.updateListing(msg)
+		case atsDone, atsError:
+			switch msg.String() {
+			case "esc":
+				return a, PopView()
+			case "enter":
 				a.state = atsListing
 				a.results = nil
+			}
+		case atsConfiguring:
+			if msg.String() == "esc" {
+				return a, PopView()
 			}
 		}
 	}
 	return a, nil
 }
 
-func (a *AITools) autoConfigure() tea.Cmd {
+func (a *AITools) updateListing(msg tea.KeyMsg) (View, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return a, PopView()
+	case "up", "k":
+		if a.cursor > 0 {
+			a.cursor--
+		}
+	case "down", "j":
+		if a.cursor < len(a.tools)-1 {
+			a.cursor++
+		}
+	case " ":
+		a.tools[a.cursor].selected = !a.tools[a.cursor].selected
+	case "a":
+		// Select all
+		for i := range a.tools {
+			a.tools[i].selected = true
+		}
+	case "enter":
+		selected := a.selectedTools()
+		if len(selected) == 0 {
+			return a, nil
+		}
+		a.state = atsConfiguring
+		return a, a.configureSelected(selected)
+	}
+	return a, nil
+}
+
+// selectedTools returns the names of currently selected tools.
+func (a *AITools) selectedTools() []string {
+	var names []string
+	for _, t := range a.tools {
+		if t.selected {
+			names = append(names, t.name)
+		}
+	}
+	return names
+}
+
+func (a *AITools) configureSelected(selected []string) tea.Cmd {
 	services := a.cfg.Services
 	devices := a.cfg.Devices
+
+	// Build a set for quick lookup
+	selectedSet := make(map[string]bool)
+	for _, name := range selected {
+		selectedSet[name] = true
+	}
+
 	return func() tea.Msg {
 		// Build endpoint list from running services
 		type endpoint struct {
@@ -138,50 +205,61 @@ func (a *AITools) autoConfigure() tea.Cmd {
 		var results []toolResult
 
 		// --- VS Code Copilot ---
-		var vscodeEndpoints []vscode.Endpoint
-		for _, ep := range endpoints {
-			vscodeEndpoints = append(vscodeEndpoints, vscode.Endpoint{
-				Family: "openai",
-				ID:     ep.serviceID,
-				Name:   fmt.Sprintf("%s (yokai)", ep.modelName),
-				URL:    fmt.Sprintf("http://%s:%d/v1", ep.host, ep.port),
-				APIKey: "none",
-			})
-		}
-		if err := vscode.AddEndpoints(vscodeEndpoints); err != nil {
-			results = append(results, toolResult{name: "VS Code Copilot", ok: false, err: err.Error()})
-		} else {
-			results = append(results, toolResult{name: "VS Code Copilot", ok: true})
+		if selectedSet["VS Code Copilot"] {
+			var vscodeEndpoints []vscode.Endpoint
+			for _, ep := range endpoints {
+				vscodeEndpoints = append(vscodeEndpoints, vscode.Endpoint{
+					Family: "openai",
+					ID:     ep.serviceID,
+					Name:   fmt.Sprintf("%s (yokai)", ep.modelName),
+					URL:    fmt.Sprintf("http://%s:%d/v1", ep.host, ep.port),
+					APIKey: "none",
+				})
+			}
+			if err := vscode.AddEndpoints(vscodeEndpoints); err != nil {
+				results = append(results, toolResult{name: "VS Code Copilot", ok: false, err: err.Error()})
+			} else {
+				results = append(results, toolResult{name: "VS Code Copilot", ok: true})
+			}
 		}
 
 		// --- OpenCode ---
-		var opencodeEndpoints []opencode.Endpoint
-		for _, ep := range endpoints {
-			opencodeEndpoints = append(opencodeEndpoints, opencode.Endpoint{
-				BaseURL:   fmt.Sprintf("http://%s:%d/v1", ep.host, ep.port),
-				ModelID:   ep.modelName,
-				ModelName: fmt.Sprintf("%s (yokai)", ep.modelName),
-			})
-		}
-		if err := opencode.AddEndpoints(opencodeEndpoints); err != nil {
-			results = append(results, toolResult{name: "OpenCode", ok: false, err: err.Error()})
-		} else {
-			results = append(results, toolResult{name: "OpenCode", ok: true})
+		if selectedSet["OpenCode"] {
+			// Migrate any legacy .opencode.json config first
+			if legacyPath, err := opencode.DetectConfigPath(); err == nil {
+				_ = opencode.MigrateLegacyConfig(legacyPath)
+			}
+
+			var opencodeEndpoints []opencode.Endpoint
+			for _, ep := range endpoints {
+				opencodeEndpoints = append(opencodeEndpoints, opencode.Endpoint{
+					BaseURL:   fmt.Sprintf("http://%s:%d/v1", ep.host, ep.port),
+					ModelID:   ep.modelName,
+					ModelName: fmt.Sprintf("%s (yokai)", ep.modelName),
+				})
+			}
+			if err := opencode.AddEndpoints(opencodeEndpoints); err != nil {
+				results = append(results, toolResult{name: "OpenCode", ok: false, err: err.Error()})
+			} else {
+				results = append(results, toolResult{name: "OpenCode", ok: true})
+			}
 		}
 
 		// --- OpenClaw ---
-		var openclawEndpoints []openclaw.Endpoint
-		for _, ep := range endpoints {
-			openclawEndpoints = append(openclawEndpoints, openclaw.Endpoint{
-				BaseURL:   fmt.Sprintf("http://%s:%d/v1", ep.host, ep.port),
-				ModelID:   ep.modelName,
-				ModelName: fmt.Sprintf("%s (yokai)", ep.modelName),
-			})
-		}
-		if err := openclaw.AddEndpoints(openclawEndpoints); err != nil {
-			results = append(results, toolResult{name: "OpenClaw", ok: false, err: err.Error()})
-		} else {
-			results = append(results, toolResult{name: "OpenClaw", ok: true})
+		if selectedSet["OpenClaw"] {
+			var openclawEndpoints []openclaw.Endpoint
+			for _, ep := range endpoints {
+				openclawEndpoints = append(openclawEndpoints, openclaw.Endpoint{
+					BaseURL:   fmt.Sprintf("http://%s:%d/v1", ep.host, ep.port),
+					ModelID:   ep.modelName,
+					ModelName: fmt.Sprintf("%s (yokai)", ep.modelName),
+				})
+			}
+			if err := openclaw.AddEndpoints(openclawEndpoints); err != nil {
+				results = append(results, toolResult{name: "OpenClaw", ok: false, err: err.Error()})
+			} else {
+				results = append(results, toolResult{name: "OpenClaw", ok: true})
+			}
 		}
 
 		return aiToolsConfigMsg{results: results}
@@ -226,20 +304,46 @@ func (a *AITools) View() string {
 		body += strings.Join(serviceLines, "\n\n")
 	}
 
-	// Show target tools
-	body += "\n\n" + lipgloss.NewStyle().Foreground(theme.Warn).Bold(true).Render("Target tools:") + "\n"
-	tools := []string{"VS Code Copilot", "OpenCode", "OpenClaw"}
-	for _, tool := range tools {
-		body += fmt.Sprintf("  %s %s\n",
-			theme.MutedStyle.Render("-"),
-			theme.PrimaryStyle.Render(tool),
+	// Show tool selection list
+	body += "\n\n" + lipgloss.NewStyle().Foreground(theme.Warn).Bold(true).Render("Configure tools:") + "\n"
+	for i, tool := range a.tools {
+		cursor := "  "
+		if i == a.cursor && a.state == atsListing {
+			cursor = "> "
+		}
+
+		checkbox := "[ ]"
+		if tool.selected {
+			checkbox = "[x]"
+		}
+
+		nameStyle := theme.PrimaryStyle
+		if i == a.cursor && a.state == atsListing {
+			nameStyle = lipgloss.NewStyle().Foreground(theme.Accent).Bold(true)
+		}
+
+		body += fmt.Sprintf("%s%s %s\n", cursor,
+			theme.MutedStyle.Render(checkbox),
+			nameStyle.Render(tool.name),
 		)
 	}
 
 	// State-specific additions
 	switch a.state {
+	case atsListing:
+		selectedCount := 0
+		for _, t := range a.tools {
+			if t.selected {
+				selectedCount++
+			}
+		}
+		if selectedCount > 0 && compatibleServices > 0 {
+			body += "\n" + theme.SuccessStyle.Render("Press Enter to configure selected tools")
+		} else if selectedCount == 0 {
+			body += "\n" + theme.MutedStyle.Render("Select at least one tool to configure")
+		}
 	case atsConfiguring:
-		body += "\n" + theme.StatusLoading() + " " + theme.PrimaryStyle.Render("Configuring AI tools...")
+		body += "\n" + theme.StatusLoading() + " " + theme.PrimaryStyle.Render("Configuring selected tools...")
 	case atsDone:
 		body += "\n"
 		for _, r := range a.results {
@@ -250,8 +354,10 @@ func (a *AITools) View() string {
 			}
 		}
 		body += "\n" + theme.MutedStyle.Render("  Backups saved as *.yokai.bak")
+		body += "\n" + theme.MutedStyle.Render("  Press Enter to return, Esc to go back")
 	case atsError:
 		body += "\n" + theme.CritStyle.Render("x "+a.err)
+		body += "\n" + theme.MutedStyle.Render("  Press Enter to return, Esc to go back")
 	}
 
 	// Responsive width
@@ -275,7 +381,10 @@ func (a *AITools) View() string {
 
 func (a *AITools) KeyBinds() []KeyBind {
 	return []KeyBind{
-		{Key: "a", Help: "auto-configure all"},
+		{Key: "j/k", Help: "navigate"},
+		{Key: "Space", Help: "toggle"},
+		{Key: "a", Help: "select all"},
+		{Key: "Enter", Help: "configure"},
 		{Key: "Esc", Help: "back"},
 	}
 }


### PR DESCRIPTION
## Summary

- **Selectable AI tools**: Replace the auto-configure-all behavior in the AI Tools view with a selectable tool list. Users can navigate with `j`/`k`, toggle individual tools with `Space`, select all with `a`, and configure only selected tools with `Enter`.
- **Fix OpenCode integration**: Rewrite the OpenCode provider config to match the actual `opencode.json` format — use `provider` (singular) key, `@ai-sdk/openai-compatible` npm package, `options.baseURL`, and register models under `provider.yokai.models`. Previously wrote to the wrong file (`.opencode.json`) with the wrong schema.
- **Legacy migration**: Add `MigrateLegacyConfig()` to clean up old-format entries (`providers`, `agents.coder.model`, `yokai_endpoints`) from any pre-existing config.

## Changes

### `internal/tui/views/aitools.go`
- Tool list with cursor navigation (`j`/`k`/arrows) and checkbox toggle (`Space`)
- `a` key selects all tools
- `Enter` configures only selected tools
- Calls `MigrateLegacyConfig` before OpenCode configuration

### `internal/opencode/settings.go`
- `DetectConfigPath()` → returns `~/.config/opencode/opencode.json` (not `.opencode.json`)
- `AddEndpointsToFile()` → writes correct OpenCode custom provider format with `npm`, `name`, `options.baseURL`, and `models` map
- `RemoveEndpoints()` → removes from `provider` (singular) key
- `HasYokaiEndpoints()` → checks both new and legacy formats
- New `MigrateLegacyConfig()` → cleans up old `providers`/`agents`/`yokai_endpoints` entries

### `internal/opencode/settings_test.go`
- All tests rewritten to validate the new config format
- Added `TestMigrateLegacyConfig` for migration path
- Added legacy format detection test for `HasYokaiEndpoints`

## Testing
- `go test ./...` — all pass
- `go vet ./...` — clean
- `go build ./cmd/yokai/` — builds successfully