### PR TITLE
fix: platform-aware file permissions (Windows chmod)

### DIFF
--- a/internal/platform/permissions.go
+++ b/internal/platform/permissions.go
@@ -1,0 +1,15 @@
+package platform
+
+import (
+	"os"
+	"runtime"
+)
+
+// ChmodIfSupported calls os.Chmod on platforms that support it (Unix).
+// On Windows, where chmod is not meaningful, it returns nil.
+func ChmodIfSupported(name string, mode os.FileMode) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return os.Chmod(name, mode)
+}

--- a/internal/platform/permissions_test.go
+++ b/internal/platform/permissions_test.go
@@ -1,0 +1,47 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestChmodIfSupported(t *testing.T) {
+	// Create a temp file to chmod.
+	dir := t.TempDir()
+	f := filepath.Join(dir, "testfile")
+	if err := os.WriteFile(f, []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	err := ChmodIfSupported(f, 0755)
+	if err != nil {
+		t.Fatalf("ChmodIfSupported returned error: %v", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(f)
+		if err != nil {
+			t.Fatalf("failed to stat file: %v", err)
+		}
+		// Mask off type bits; compare permission bits only.
+		got := info.Mode().Perm()
+		if got != 0755 {
+			t.Errorf("expected mode 0755, got %04o", got)
+		}
+	}
+}
+
+func TestChmodIfSupported_NonexistentFile(t *testing.T) {
+	err := ChmodIfSupported("/no/such/file", 0755)
+	if runtime.GOOS == "windows" {
+		if err != nil {
+			t.Fatalf("expected nil on Windows, got %v", err)
+		}
+	} else {
+		if err == nil {
+			t.Fatal("expected error for nonexistent file on Unix")
+		}
+	}
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/spencerbull/yokai/internal/platform"
 )
 
 const (
@@ -179,7 +181,7 @@ func Run(currentVersion string) error {
 	}
 
 	// Make it executable
-	if err := os.Chmod(currentBinaryPath, 0755); err != nil {
+	if err := platform.ChmodIfSupported(currentBinaryPath, 0755); err != nil {
 		return fmt.Errorf("failed to make binary executable: %w", err)
 	}
 
@@ -252,7 +254,7 @@ func extractTarGz(src, dst string) error {
 				return err
 			}
 
-			if err := os.Chmod(path, header.FileInfo().Mode()); err != nil {
+			if err := platform.ChmodIfSupported(path, header.FileInfo().Mode()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Adds platform helpers that skip chmod on Windows where it is unsupported. Replaces bare os.Chmod calls in upgrade flow with ChmodIfSupported. Remote SSH chmod commands are unaffected.

## Summary
- Adds `internal/platform/permissions.go` with `ChmodIfSupported` helper that no-ops on Windows
- Replaces `os.Chmod` calls in `internal/upgrade/upgrade.go` (lines 182, 255) with `platform.ChmodIfSupported`
- Adds tests in `internal/platform/permissions_test.go`
- Remote SSH chmod commands in bootstrap.go are intentionally unchanged (they run on Linux hosts)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/platform/... ./internal/upgrade/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)