### PR TITLE
feat: Add confirmation dialogs for destructive actions

### DIFF
--- a/internal/tui/components/confirm.go
+++ b/internal/tui/components/confirm.go
@@ -1,0 +1,70 @@
+package components
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spencerbull/yokai/internal/tui/theme"
+)
+
+// ConfirmDialog renders a centered modal-style confirmation card.
+type ConfirmDialog struct {
+	Message   string
+	YesActive bool // true = "Yes" highlighted, false = "No" highlighted
+	Width     int
+}
+
+// NewConfirmDialog creates a confirm dialog defaulting to "No" selected.
+func NewConfirmDialog(message string, width int) ConfirmDialog {
+	return ConfirmDialog{
+		Message:   message,
+		YesActive: false,
+		Width:     width,
+	}
+}
+
+// Render returns the styled confirmation dialog string.
+func (c ConfirmDialog) Render() string {
+	cardWidth := 50
+	if c.Width > 0 && c.Width < 60 {
+		cardWidth = c.Width - 10
+		if cardWidth < 30 {
+			cardWidth = 30
+		}
+	}
+
+	msg := lipgloss.NewStyle().
+		Foreground(theme.TextPrimary).
+		Width(cardWidth - 6).
+		Render(c.Message)
+
+	activeStyle := lipgloss.NewStyle().
+		Foreground(theme.Background).
+		Background(theme.Accent).
+		Padding(0, 2).
+		Bold(true)
+
+	inactiveStyle := lipgloss.NewStyle().
+		Foreground(theme.TextMuted).
+		Padding(0, 2)
+
+	var yesBtn, noBtn string
+	if c.YesActive {
+		yesBtn = activeStyle.Render("Yes")
+		noBtn = inactiveStyle.Render("No")
+	} else {
+		yesBtn = inactiveStyle.Render("Yes")
+		noBtn = activeStyle.Render("No")
+	}
+
+	buttons := lipgloss.JoinHorizontal(lipgloss.Center, yesBtn, "  ", noBtn)
+
+	content := lipgloss.JoinVertical(lipgloss.Center, msg, "", buttons)
+
+	card := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(theme.Border).
+		Padding(1, 2).
+		Width(cardWidth).
+		Render(content)
+
+	return card
+}

--- a/internal/tui/views/confirm.go
+++ b/internal/tui/views/confirm.go
@@ -1,0 +1,85 @@
+package views
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spencerbull/yokai/internal/tui/components"
+	"github.com/spencerbull/yokai/internal/tui/theme"
+)
+
+// ConfirmView presents a confirmation dialog and dispatches callbacks.
+type ConfirmView struct {
+	dialog    components.ConfirmDialog
+	onConfirm tea.Cmd
+	onCancel  tea.Cmd
+	width     int
+	height    int
+}
+
+// NewConfirmView creates a confirmation view.
+// onConfirm is executed (then view is popped) when user confirms.
+// onCancel is executed (then view is popped) when user cancels. Can be nil.
+func NewConfirmView(message string, onConfirm, onCancel tea.Cmd) *ConfirmView {
+	return &ConfirmView{
+		dialog:    components.NewConfirmDialog(message, 0),
+		onConfirm: onConfirm,
+		onCancel:  onCancel,
+	}
+}
+
+func (v *ConfirmView) Init() tea.Cmd { return nil }
+
+func (v *ConfirmView) Update(msg tea.Msg) (View, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		v.width = msg.Width
+		if v.width > theme.MaxContentWidth-2*theme.ContentPadding {
+			v.width = theme.MaxContentWidth - 2*theme.ContentPadding
+		}
+		v.height = msg.Height
+		v.dialog.Width = v.width
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "left", "h":
+			v.dialog.YesActive = true
+		case "right", "l":
+			v.dialog.YesActive = false
+		case "y":
+			v.dialog.YesActive = true
+			return v, tea.Batch(PopView(), v.onConfirm)
+		case "enter":
+			if v.dialog.YesActive {
+				return v, tea.Batch(PopView(), v.onConfirm)
+			}
+			return v, tea.Batch(PopView(), v.onCancel)
+		case "n", "esc":
+			return v, tea.Batch(PopView(), v.onCancel)
+		}
+	}
+	return v, nil
+}
+
+func (v *ConfirmView) View() string {
+	if v.width == 0 {
+		v.width = theme.MaxContentWidth - 2*theme.ContentPadding
+	}
+	v.dialog.Width = v.width
+
+	card := v.dialog.Render()
+
+	return lipgloss.Place(v.width, v.height,
+		lipgloss.Center, lipgloss.Center,
+		card)
+}
+
+func (v *ConfirmView) InputActive() bool { return false }
+
+func (v *ConfirmView) KeyBinds() []KeyBind {
+	return []KeyBind{
+		{Key: "←/→", Help: "select"},
+		{Key: "y", Help: "yes"},
+		{Key: "n/Esc", Help: "no"},
+		{Key: "Enter", Help: "confirm"},
+	}
+}

--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -196,7 +196,10 @@ func (d *Dashboard) Update(msg tea.Msg) (View, tea.Cmd) {
 			}
 		case "s":
 			if container := d.getSelectedContainer(); container != nil {
-				return d, d.stopService(container.ID)
+				containerID := container.ID
+				name := container.Name
+				msg := fmt.Sprintf("Stop service %q?", name)
+				return d, Navigate(NewConfirmView(msg, d.stopService(containerID), nil))
 			}
 		case "r":
 			if container := d.getSelectedContainer(); container != nil {

--- a/internal/tui/views/devices.go
+++ b/internal/tui/views/devices.go
@@ -124,11 +124,17 @@ func (dm *DeviceManager) Update(msg tea.Msg) (View, tea.Cmd) {
 			}
 		case "x":
 			if len(dm.cfg.Devices) > 0 {
-				dm.cfg.RemoveDevice(dm.cfg.Devices[dm.cursor].ID)
-				_ = config.Save(dm.cfg)
-				if dm.cursor >= len(dm.cfg.Devices) && dm.cursor > 0 {
-					dm.cursor--
+				device := dm.cfg.Devices[dm.cursor]
+				onConfirm := func() tea.Msg {
+					dm.cfg.RemoveDevice(device.ID)
+					_ = config.Save(dm.cfg)
+					if dm.cursor >= len(dm.cfg.Devices) && dm.cursor > 0 {
+						dm.cursor--
+					}
+					return nil
 				}
+				msg := fmt.Sprintf("Remove device %q? This cannot be undone.", device.Label)
+				return dm, Navigate(NewConfirmView(msg, onConfirm, nil))
 			}
 		case "esc":
 			return dm, PopView()


### PR DESCRIPTION
## Feature

Adds a reusable confirmation dialog component and wires it into destructive actions.

### Changes
- New `internal/tui/components/confirm.go` — reusable ConfirmDialog component
- New `internal/tui/views/confirm.go` — ConfirmView wrapping the component  
- Device delete (`x` in Device Manager) now requires confirmation
- Service stop (`s` on Dashboard) now requires confirmation
- Service restart (`r`) does NOT require confirmation (safe operation)

### UX
- y/Enter confirms, n/Esc cancels
- Left/Right toggles between Yes/No
- Tokyo Night themed, responsive width
- Message shows the specific resource name being affected