### PR TITLE
fix: UX polish — consistent navigation, better error states, cleanup

### DIFF
--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -211,16 +211,17 @@ func (d *Dashboard) Update(msg tea.Msg) (View, tea.Cmd) {
 }
 
 func (d *Dashboard) View() string {
-	if d.lastError != nil {
-		return d.renderError()
-	}
-
 	// Guard: if we haven't received a WindowSizeMsg yet, use a sensible default.
 	if d.width == 0 {
 		d.width = theme.MaxContentWidth - 2*theme.ContentPadding
 	}
 
 	var sections []string
+
+	// Error banner when daemon is offline
+	if d.lastError != nil {
+		sections = append(sections, d.renderErrorBanner())
+	}
 
 	// Header
 	header := d.renderHeader()
@@ -298,16 +299,23 @@ func (d *Dashboard) renderStackedLayout() []string {
 	return sections
 }
 
-func (d *Dashboard) renderError() string {
-	errorMsg := "Daemon not running. Start with: yokai daemon"
-	if d.lastError != nil {
-		errorMsg = fmt.Sprintf("Error connecting to daemon: %v", d.lastError)
+func (d *Dashboard) renderErrorBanner() string {
+	bannerWidth := d.width - 4
+	if bannerWidth < 30 {
+		bannerWidth = 30
 	}
 
+	msg := fmt.Sprintf("  Daemon offline: %v", d.lastError)
+	hint := "  Retrying automatically..."
+
+	content := theme.WarnStyle.Render(msg) + "\n" + theme.MutedStyle.Render(hint)
+
 	return lipgloss.NewStyle().
-		Foreground(theme.Crit).
-		Bold(true).
-		Render(errorMsg)
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(theme.Warn).
+		Padding(0, 1).
+		Width(bannerWidth).
+		Render(content)
 }
 
 func (d *Dashboard) renderHeader() string {

--- a/internal/tui/views/deploy.go
+++ b/internal/tui/views/deploy.go
@@ -271,8 +271,6 @@ func (d *Deploy) Update(msg tea.Msg) (View, tea.Cmd) {
 
 func (d *Deploy) updateType(msg tea.KeyMsg) (View, tea.Cmd) {
 	switch msg.String() {
-	case "backspace":
-		return d, PopView()
 	case "up", "k":
 		if d.cursor > 0 {
 			d.cursor--
@@ -300,9 +298,6 @@ func (d *Deploy) updateType(msg tea.KeyMsg) (View, tea.Cmd) {
 
 func (d *Deploy) updateDevice(msg tea.KeyMsg) (View, tea.Cmd) {
 	switch msg.String() {
-	case "backspace":
-		d.currentStep--
-		return d, nil
 	case "up", "k":
 		if d.cursor > 0 {
 			d.cursor--

--- a/internal/tui/views/devices.go
+++ b/internal/tui/views/devices.go
@@ -109,6 +109,18 @@ func (dm *DeviceManager) Update(msg tea.Msg) (View, tea.Cmd) {
 					return dm, dm.upgradeDevice(device)
 				}
 			}
+		case "T":
+			// Test ALL device connections
+			var cmds []tea.Cmd
+			for _, device := range dm.cfg.Devices {
+				if !dm.testing[device.ID] {
+					dm.testing[device.ID] = true
+					cmds = append(cmds, dm.testConnection(device))
+				}
+			}
+			if len(cmds) > 0 {
+				return dm, tea.Batch(cmds...)
+			}
 		case "U":
 			// Upgrade ALL device agents
 			var cmds []tea.Cmd
@@ -360,6 +372,7 @@ func (dm *DeviceManager) KeyBinds() []KeyBind {
 		{Key: "a", Help: "add device"},
 		{Key: "e", Help: "edit"},
 		{Key: "t", Help: "test connection"},
+		{Key: "T", Help: "test all"},
 		{Key: "u", Help: "upgrade agent"},
 		{Key: "U", Help: "upgrade all"},
 		{Key: "x", Help: "remove"},

--- a/internal/tui/views/hftoken.go
+++ b/internal/tui/views/hftoken.go
@@ -231,7 +231,7 @@ func (h *HFToken) View() string {
 		if h.err != "" {
 			body += "\n" + theme.CritStyle.Render(h.err)
 		}
-		body += "\n\n" + theme.MutedStyle.Render("Get a token at: https://huggingface.co/settings/tokens\nPress 's' to skip not available in input mode")
+		body += "\n\n" + theme.MutedStyle.Render("Get a token at: https://huggingface.co/settings/tokens")
 
 	case hfValidating:
 		body = theme.StatusLoading() + " " + theme.PrimaryStyle.Render("Validating token...")


### PR DESCRIPTION
## UX Polish

Bundle of small but important UX fixes.

### Changes
1. **Deploy wizard navigation** — Unified Esc as the back key for all steps (was inconsistent with Backspace)
2. **HFToken help text** — Removed confusing 'skip not available in input mode' message from input state
3. **Dashboard error state** — Shows a degraded dashboard with warning banner when daemon is offline instead of replacing entire view with one error line
4. **Bulk device test** — Added `T` (Shift+T) to test all devices at once (matching `U` for upgrade all)
5. **Dead code cleanup** — Removed unused `DefaultTabs()` function