### PR TITLE
feat: Add expandable service detail panel on dashboard

### DIFF
--- a/internal/tui/components/servicedetail.go
+++ b/internal/tui/components/servicedetail.go
@@ -1,0 +1,179 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spencerbull/yokai/internal/tui/theme"
+)
+
+// ServiceDetailData holds all the info needed for the detail panel.
+type ServiceDetailData struct {
+	Name          string
+	Image         string
+	Model         string
+	ContainerID   string
+	Status        string
+	Health        string
+	Port          int
+	Device        string
+	CPUPercent    float64
+	MemUsedMB     int64
+	GPUMemMB      int64
+	Uptime        string
+	CPUHistory    []float64
+}
+
+// ServiceDetail renders an expanded detail card for a selected service.
+type ServiceDetail struct {
+	Data  ServiceDetailData
+	Width int
+}
+
+// NewServiceDetail creates a new service detail component.
+func NewServiceDetail(data ServiceDetailData, width int) ServiceDetail {
+	return ServiceDetail{Data: data, Width: width}
+}
+
+// Render returns the rendered detail panel.
+func (s ServiceDetail) Render() string {
+	if s.Width < 30 {
+		s.Width = 30
+	}
+
+	label := theme.MutedStyle.Render
+	value := theme.PrimaryStyle.Render
+
+	// Truncate container ID to 12 chars
+	cid := s.Data.ContainerID
+	if len(cid) > 12 {
+		cid = cid[:12]
+	}
+
+	portStr := "-"
+	if s.Data.Port > 0 {
+		portStr = fmt.Sprintf("%d", s.Data.Port)
+	}
+
+	cpuStr := fmt.Sprintf("%.1f%%", s.Data.CPUPercent)
+	memStr := formatMem(s.Data.MemUsedMB)
+	gpuMemStr := formatMem(s.Data.GPUMemMB)
+
+	// Health indicator dot
+	healthDot := s.healthDot()
+
+	// Left column: Name, Image, Model, Container ID
+	leftPairs := []struct{ k, v string }{
+		{"Name", s.Data.Name},
+		{"Image", s.Data.Image},
+		{"Model", s.Data.Model},
+		{"Container", cid},
+	}
+
+	// Right column: Status, Port, CPU, Memory, GPU Mem, Uptime
+	statusDisplay := healthDot + " " + s.statusLabel()
+	rightPairs := []struct{ k, v string }{
+		{"Status", statusDisplay},
+		{"Port", portStr},
+		{"CPU", cpuStr},
+		{"Memory", memStr},
+		{"GPU Mem", gpuMemStr},
+		{"Uptime", s.Data.Uptime},
+	}
+
+	// Calculate column widths
+	innerWidth := s.Width - 4 // border + padding
+	colWidth := (innerWidth - 3) / 2
+
+	leftLines := renderPairs(leftPairs, colWidth, label, value)
+	rightLines := renderPairs(rightPairs, colWidth, label, value)
+
+	// Pad to same height
+	for len(leftLines) < len(rightLines) {
+		leftLines = append(leftLines, strings.Repeat(" ", colWidth))
+	}
+	for len(rightLines) < len(leftLines) {
+		rightLines = append(rightLines, strings.Repeat(" ", colWidth))
+	}
+
+	leftCol := lipgloss.NewStyle().Width(colWidth).Render(strings.Join(leftLines, "\n"))
+	rightCol := lipgloss.NewStyle().Width(colWidth).Render(strings.Join(rightLines, "\n"))
+
+	body := lipgloss.JoinHorizontal(lipgloss.Top, leftCol, "   ", rightCol)
+
+	// Mini CPU sparkline if history available
+	if len(s.Data.CPUHistory) > 0 {
+		sparkWidth := innerWidth
+		if sparkWidth > 60 {
+			sparkWidth = 60
+		}
+		cpuLabel := label("CPU ") + value(cpuStr) + " "
+		spark := NewSparkline(s.Data.CPUHistory, sparkWidth-len("CPU 00.0% "), theme.Good)
+		body += "\n\n" + cpuLabel + spark.Render()
+	}
+
+	// Action hints
+	hints := theme.MutedStyle.Render("l") + theme.PrimaryStyle.Render(":logs") + "  " +
+		theme.MutedStyle.Render("s") + theme.PrimaryStyle.Render(":stop") + "  " +
+		theme.MutedStyle.Render("r") + theme.PrimaryStyle.Render(":restart") + "  " +
+		theme.MutedStyle.Render("Esc") + theme.PrimaryStyle.Render(":collapse")
+	body += "\n\n" + hints
+
+	// Title with service name
+	title := theme.TitleStyle.Render(" " + s.Data.Name)
+	return theme.RenderPanel(title, body, s.Width)
+}
+
+func (s ServiceDetail) healthDot() string {
+	h := s.Data.Health
+	if h == "" {
+		h = s.Data.Status
+	}
+	switch h {
+	case "healthy", "running":
+		return lipgloss.NewStyle().Foreground(theme.Good).Render("●")
+	case "starting":
+		return lipgloss.NewStyle().Foreground(theme.Warn).Render("◐")
+	case "unhealthy", "error":
+		return lipgloss.NewStyle().Foreground(theme.Crit).Render("●")
+	case "stopped":
+		return lipgloss.NewStyle().Foreground(theme.TextMuted).Render("○")
+	default:
+		return lipgloss.NewStyle().Foreground(theme.TextMuted).Render("?")
+	}
+}
+
+func (s ServiceDetail) statusLabel() string {
+	h := s.Data.Health
+	if h == "" {
+		h = s.Data.Status
+	}
+	switch h {
+	case "healthy":
+		return lipgloss.NewStyle().Foreground(theme.Good).Render("healthy")
+	case "running":
+		return lipgloss.NewStyle().Foreground(theme.Good).Render("running")
+	case "starting":
+		return lipgloss.NewStyle().Foreground(theme.Warn).Render("starting")
+	case "unhealthy":
+		return lipgloss.NewStyle().Foreground(theme.Crit).Render("unhealthy")
+	case "error":
+		return lipgloss.NewStyle().Foreground(theme.Crit).Render("error")
+	case "stopped":
+		return lipgloss.NewStyle().Foreground(theme.TextMuted).Render("stopped")
+	default:
+		return theme.PrimaryStyle.Render(h)
+	}
+}
+
+func renderPairs(pairs []struct{ k, v string }, width int, labelFn, valueFn func(...string) string) []string {
+	var lines []string
+	for _, p := range pairs {
+		k := labelFn(pad(p.k+":", 12))
+		v := valueFn(p.v)
+		line := k + v
+		lines = append(lines, line)
+	}
+	return lines
+}

--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -24,6 +24,7 @@ type Dashboard struct {
 
 	// Service selection
 	selectedService int
+	showDetail      bool
 
 	// Live metrics data
 	metrics   map[string]*DashboardMetrics
@@ -184,13 +185,23 @@ func (d *Dashboard) Update(msg tea.Msg) (View, tea.Cmd) {
 			return d, Navigate(NewAITools(d.cfg, d.version))
 		case "?":
 			return d, Navigate(NewHelp(d.version))
+		case "esc":
+			if d.showDetail {
+				d.showDetail = false
+				return d, nil
+			}
 		case "j", "down":
 			d.moveServiceCursor(1)
+			d.showDetail = false
 		case "k", "up":
 			d.moveServiceCursor(-1)
-		case "enter", "l":
+			d.showDetail = false
+		case "enter":
+			if len(d.serviceContainers) > 0 {
+				d.showDetail = !d.showDetail
+			}
+		case "l":
 			if container := d.getSelectedContainer(); container != nil {
-				// Find device ID for this container
 				deviceID := d.findDeviceIDForContainer(container.ID)
 				return d, Navigate(NewLogViewer(d.cfg, d.version, container.Name, deviceID, container.ID))
 			}
@@ -237,6 +248,13 @@ func (d *Dashboard) View() string {
 	// Service list (always full width, bottom)
 	serviceList := d.renderServiceList()
 	sections = append(sections, serviceList)
+
+	// Service detail panel (expandable)
+	if d.showDetail {
+		if detail := d.renderServiceDetail(); detail != "" {
+			sections = append(sections, detail)
+		}
+	}
 
 	// Use Left alignment so the outer lipgloss.Place() in app.go handles centering.
 	// Wrap at d.width so the assembled block has the correct width for centering.
@@ -542,6 +560,46 @@ func (d *Dashboard) buildServiceRows() []components.ServiceRow {
 	return rows
 }
 
+func (d *Dashboard) renderServiceDetail() string {
+	container := d.getSelectedContainer()
+	if container == nil {
+		return ""
+	}
+
+	displayName := strings.TrimPrefix(container.Name, "yokai-")
+	deviceID := d.findDeviceIDForContainer(container.ID)
+	device := d.findDevice(deviceID)
+	deviceLabel := ""
+	if device != nil {
+		deviceLabel = device.Label
+	}
+
+	// Gather CPU history for this container's device
+	var cpuHistory []float64
+	if vals, ok := d.cpuHistory[deviceID]; ok {
+		cpuHistory = vals
+	}
+
+	data := components.ServiceDetailData{
+		Name:        displayName,
+		Image:       container.Image,
+		Model:       d.getServiceModel(*container),
+		ContainerID: container.ID,
+		Status:      container.Status,
+		Health:      container.Health,
+		Port:        extractExternalPort(container.Ports),
+		Device:      deviceLabel,
+		CPUPercent:  container.CPUPercent,
+		MemUsedMB:   container.MemUsedMB,
+		GPUMemMB:    container.GPUMemMB,
+		Uptime:      formatUptime(container.UptimeSeconds),
+		CPUHistory:  cpuHistory,
+	}
+
+	detail := components.NewServiceDetail(data, d.width)
+	return detail.Render()
+}
+
 func (d *Dashboard) pollMetrics() tea.Cmd {
 	return func() tea.Msg {
 		daemonURL := fmt.Sprintf("http://%s/metrics", d.cfg.Daemon.Listen)
@@ -789,6 +847,7 @@ func (d *Dashboard) InputActive() bool { return false }
 
 func (d *Dashboard) KeyBinds() []KeyBind {
 	return []KeyBind{
+		{Key: "enter", Help: "detail"},
 		{Key: "n", Help: "new"},
 		{Key: "s", Help: "stop"},
 		{Key: "r", Help: "restart"},


### PR DESCRIPTION
## Feature

Adds an inline expandable detail panel for services on the dashboard.

### Changes
- New `internal/tui/components/servicedetail.go` — ServiceDetail component
- Updated Dashboard: Enter toggles detail panel instead of jumping to logs
- `l` key still opens log viewer (works with or without detail shown)
- Esc collapses detail panel (doesn't pop view)

### Detail Panel Shows
- Two-column layout: Name, Image, Model, Container ID | Status, Port, CPU, Memory, GPU Mem, Uptime
- Health indicator dot (green/yellow/red)
- Action hints: `l:logs  s:stop  r:restart  Esc:collapse`
- Tokyo Night themed with rounded border