### PR TITLE
feat: Add toast notification system for transient feedback

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	zone "github.com/lrstanley/bubblezone"
 	"github.com/spencerbull/yokai/internal/config"
 	"github.com/spencerbull/yokai/internal/tui/components"
@@ -32,6 +34,7 @@ type App struct {
 	quitting    bool
 	activeTab   int
 	showTabs    bool // show tab bar (hidden during onboarding)
+	toasts      components.ToastManager
 }
 
 // newApp creates the root app model.
@@ -39,6 +42,7 @@ func newApp(cfg *config.Config, version string) *App {
 	app := &App{
 		cfg:     cfg,
 		version: version,
+		toasts:  components.NewToastManager(),
 	}
 
 	// If no devices configured, start with onboarding; otherwise dashboard
@@ -92,6 +96,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.width = msg.Width
 		a.height = msg.Height
+	}
+
+	// Handle toast messages
+	if toastCmd := a.toasts.Update(msg); toastCmd != nil {
+		return a, toastCmd
+	}
+	if showMsg, ok := msg.(components.ShowToastMsg); ok {
+		cmd := a.toasts.Add(showMsg)
+		return a, cmd
 	}
 
 	// Check for navigation messages
@@ -201,7 +214,23 @@ func (a *App) View() string {
 	sections = append(sections, bar)
 
 	assembled := lipgloss.JoinVertical(lipgloss.Center, sections...)
-	return zone.Scan(lipgloss.Place(a.width, a.height, lipgloss.Center, lipgloss.Top, assembled))
+	output := lipgloss.Place(a.width, a.height, lipgloss.Center, lipgloss.Top, assembled)
+
+	// Overlay toasts in the top-right corner
+	if toastView := a.toasts.View(a.width); toastView != "" {
+		// Render toasts on top of the first lines of output
+		toastLines := strings.Split(toastView, "\n")
+		outputLines := strings.Split(output, "\n")
+		for i, tl := range toastLines {
+			if i < len(outputLines) {
+				// Overlay toast line (right-aligned) onto the output line
+				outputLines[i] = overlayRight(outputLines[i], tl, a.width)
+			}
+		}
+		output = strings.Join(outputLines, "\n")
+	}
+
+	return zone.Scan(output)
 }
 
 // navigate pushes current view onto stack and switches to the target.
@@ -268,6 +297,27 @@ func renderKeybindBar(binds []views.KeyBind, width int) string {
 		Padding(0, 1).
 		Width(width).
 		Render(line)
+}
+
+// overlayRight places the overlay string at the right edge of the base string,
+// respecting terminal width. Both strings may contain ANSI escape sequences.
+func overlayRight(base, overlay string, width int) string {
+	overlayW := ansi.StringWidth(overlay)
+	baseW := ansi.StringWidth(base)
+
+	if overlayW >= width {
+		return overlay
+	}
+
+	startCol := width - overlayW
+	if startCol > baseW {
+		// Pad base to reach the overlay position
+		return base + strings.Repeat(" ", startCol-baseW) + overlay
+	}
+
+	// Truncate base and append overlay
+	truncated := ansi.Truncate(base, startCol, "")
+	return truncated + overlay
 }
 
 // Run starts the TUI application.

--- a/internal/tui/components/toast.go
+++ b/internal/tui/components/toast.go
@@ -1,0 +1,139 @@
+package components
+
+import (
+	"fmt"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spencerbull/yokai/internal/tui/theme"
+)
+
+// ToastLevel defines the severity of a toast notification.
+type ToastLevel int
+
+const (
+	ToastInfo ToastLevel = iota
+	ToastSuccess
+	ToastWarn
+	ToastError
+)
+
+const (
+	defaultToastDuration = 3 * time.Second
+	toastMaxWidth        = 40
+)
+
+// ShowToastMsg is sent by views to display a toast notification.
+type ShowToastMsg struct {
+	Message  string
+	Level    ToastLevel
+	Duration time.Duration
+}
+
+// toastExpiredMsg is sent when a toast's timer expires.
+type toastExpiredMsg struct {
+	id int
+}
+
+type toast struct {
+	id        int
+	message   string
+	level     ToastLevel
+	createdAt time.Time
+	duration  time.Duration
+}
+
+// ToastManager manages a stack of toast notifications.
+type ToastManager struct {
+	toasts []toast
+	nextID int
+}
+
+// NewToastManager creates an empty ToastManager.
+func NewToastManager() ToastManager {
+	return ToastManager{}
+}
+
+// Add creates a new toast and returns a tick command for auto-dismiss.
+func (tm *ToastManager) Add(msg ShowToastMsg) tea.Cmd {
+	dur := msg.Duration
+	if dur == 0 {
+		dur = defaultToastDuration
+	}
+
+	t := toast{
+		id:        tm.nextID,
+		message:   msg.Message,
+		level:     msg.Level,
+		createdAt: time.Now(),
+		duration:  dur,
+	}
+	tm.nextID++
+	tm.toasts = append(tm.toasts, t)
+
+	id := t.id
+	return tea.Tick(dur, func(time.Time) tea.Msg {
+		return toastExpiredMsg{id: id}
+	})
+}
+
+// Update handles toast expiry messages. Returns a command if needed.
+func (tm *ToastManager) Update(msg tea.Msg) tea.Cmd {
+	if exp, ok := msg.(toastExpiredMsg); ok {
+		for i, t := range tm.toasts {
+			if t.id == exp.id {
+				tm.toasts = append(tm.toasts[:i], tm.toasts[i+1:]...)
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// View renders the toast stack. Returns empty string if no toasts.
+func (tm *ToastManager) View(termWidth int) string {
+	if len(tm.toasts) == 0 {
+		return ""
+	}
+
+	var rendered []string
+	for _, t := range tm.toasts {
+		rendered = append(rendered, renderToast(t))
+	}
+
+	stack := lipgloss.JoinVertical(lipgloss.Right, rendered...)
+
+	// Place in top-right corner
+	return lipgloss.PlaceHorizontal(termWidth, lipgloss.Right, stack)
+}
+
+func renderToast(t toast) string {
+	var icon string
+	var borderColor lipgloss.Color
+
+	switch t.level {
+	case ToastInfo:
+		icon = "ℹ"
+		borderColor = theme.Accent
+	case ToastSuccess:
+		icon = "✓"
+		borderColor = theme.Good
+	case ToastWarn:
+		icon = "⚠"
+		borderColor = theme.Warn
+	case ToastError:
+		icon = "✗"
+		borderColor = theme.Crit
+	}
+
+	content := fmt.Sprintf("%s %s", icon, t.message)
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Foreground(theme.TextPrimary).
+		Padding(0, 1).
+		MaxWidth(toastMaxWidth).
+		Render(content)
+}

--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -54,6 +54,14 @@ type DevicesMsg struct {
 
 type tickMsg struct{}
 
+type serviceStopMsg struct {
+	err error
+}
+
+type serviceRestartMsg struct {
+	err error
+}
+
 // DashboardMetrics represents the metrics data from the daemon API
 type DashboardMetrics struct {
 	CPU        CPUData         `json:"cpu"`
@@ -161,6 +169,18 @@ func (d *Dashboard) Update(msg tea.Msg) (View, tea.Cmd) {
 
 	case tickMsg:
 		return d, tea.Batch(d.pollMetrics(), d.pollDevices())
+
+	case serviceStopMsg:
+		if msg.err != nil {
+			return d, ShowToast("Stop failed: "+msg.err.Error(), ToastError)
+		}
+		return d, ShowToast("Service stopped", ToastSuccess)
+
+	case serviceRestartMsg:
+		if msg.err != nil {
+			return d, ShowToast("Restart failed: "+msg.err.Error(), ToastError)
+		}
+		return d, ShowToast("Service restarting...", ToastInfo)
 
 	case tea.MouseMsg:
 		if msg.Action == tea.MouseActionRelease {
@@ -734,15 +754,15 @@ func (d *Dashboard) stopService(containerID string) tea.Cmd {
 	return func() tea.Msg {
 		deviceID := d.findDeviceIDForContainer(containerID)
 		if deviceID == "" {
-			return nil
+			return serviceStopMsg{err: fmt.Errorf("device not found")}
 		}
 		url := fmt.Sprintf("http://%s/containers/%s/%s/stop", d.cfg.Daemon.Listen, deviceID, containerID)
 		resp, err := http.Post(url, "application/json", nil)
 		if err != nil {
-			return nil // Could return error message
+			return serviceStopMsg{err: err}
 		}
-		_ = resp.Body.Close() // Best-effort close of stop response body.
-		return nil
+		_ = resp.Body.Close()
+		return serviceStopMsg{}
 	}
 }
 
@@ -750,15 +770,15 @@ func (d *Dashboard) restartService(containerID string) tea.Cmd {
 	return func() tea.Msg {
 		deviceID := d.findDeviceIDForContainer(containerID)
 		if deviceID == "" {
-			return nil
+			return serviceRestartMsg{err: fmt.Errorf("device not found")}
 		}
 		url := fmt.Sprintf("http://%s/containers/%s/%s/restart", d.cfg.Daemon.Listen, deviceID, containerID)
 		resp, err := http.Post(url, "application/json", nil)
 		if err != nil {
-			return nil // Could return error message
+			return serviceRestartMsg{err: err}
 		}
-		_ = resp.Body.Close() // Best-effort close of restart response body.
-		return nil
+		_ = resp.Body.Close()
+		return serviceRestartMsg{}
 	}
 }
 

--- a/internal/tui/views/deploy.go
+++ b/internal/tui/views/deploy.go
@@ -211,8 +211,11 @@ func (d *Deploy) Update(msg tea.Msg) (View, tea.Cmd) {
 			d.history.AddModel(d.modelInput.Value())
 			_ = config.SaveHistory(d.history)
 
-			// Success - pop back to dashboard
-			return d, PopView()
+			// Success - pop back to dashboard with toast
+			return d, tea.Batch(
+				PopView(),
+				ShowToast("Service deployed successfully", ToastSuccess),
+			)
 		}
 		return d, nil
 

--- a/internal/tui/views/devices.go
+++ b/internal/tui/views/devices.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spencerbull/yokai/internal/config"
 	sshpkg "github.com/spencerbull/yokai/internal/ssh"
+	"github.com/spencerbull/yokai/internal/tui/components"
 	"github.com/spencerbull/yokai/internal/tui/theme"
 )
 
@@ -67,12 +68,21 @@ func (dm *DeviceManager) Update(msg tea.Msg) (View, tea.Cmd) {
 	case connectionTestResult:
 		dm.testResults[msg.deviceID] = msg
 		delete(dm.testing, msg.deviceID)
+		if msg.err != nil {
+			return dm, ShowToast("Connection failed: "+msg.err.Error(), ToastError)
+		}
+		if msg.online {
+			return dm, ShowToast("Device online", ToastSuccess)
+		}
 		return dm, nil
 
 	case upgradeResultMsg:
 		delete(dm.upgrading, msg.deviceID)
 		dm.upgradeResults[msg.deviceID] = &msg
-		return dm, nil
+		if msg.err != nil {
+			return dm, ShowToast("Upgrade failed: "+msg.err.Error(), ToastError)
+		}
+		return dm, ShowToast("Agent upgraded successfully", ToastSuccess)
 
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -146,7 +156,11 @@ func (dm *DeviceManager) Update(msg tea.Msg) (View, tea.Cmd) {
 					return nil
 				}
 				msg := fmt.Sprintf("Remove device %q? This cannot be undone.", device.Label)
-				return dm, Navigate(NewConfirmView(msg, onConfirm, nil))
+				onConfirmWithToast := func() tea.Msg {
+					onConfirm()
+					return components.ShowToastMsg{Message: "Device removed", Level: ToastSuccess}
+				}
+				return dm, Navigate(NewConfirmView(msg, onConfirmWithToast, nil))
 			}
 		case "esc":
 			return dm, PopView()

--- a/internal/tui/views/messages.go
+++ b/internal/tui/views/messages.go
@@ -1,6 +1,11 @@
 package views
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spencerbull/yokai/internal/tui/components"
+)
 
 // View is the interface all TUI screens implement.
 type View interface {
@@ -47,5 +52,34 @@ func NavigateReplace(target View) tea.Cmd {
 func PopView() tea.Cmd {
 	return func() tea.Msg {
 		return PopViewMsg{}
+	}
+}
+
+// Toast level aliases so views don't need to import components directly.
+const (
+	ToastInfo    = components.ToastInfo
+	ToastSuccess = components.ToastSuccess
+	ToastWarn    = components.ToastWarn
+	ToastError   = components.ToastError
+)
+
+// ShowToast returns a tea.Cmd that shows a toast notification.
+func ShowToast(message string, level components.ToastLevel) tea.Cmd {
+	return func() tea.Msg {
+		return components.ShowToastMsg{
+			Message: message,
+			Level:   level,
+		}
+	}
+}
+
+// ShowToastWithDuration returns a tea.Cmd that shows a toast with a custom duration.
+func ShowToastWithDuration(message string, level components.ToastLevel, duration time.Duration) tea.Cmd {
+	return func() tea.Msg {
+		return components.ShowToastMsg{
+			Message:  message,
+			Level:    level,
+			Duration: duration,
+		}
 	}
 }


### PR DESCRIPTION
## Feature

Adds a toast/notification system for transient user feedback throughout the TUI.

### Changes
- New `internal/tui/components/toast.go` — ToastManager with auto-dismiss
- Updated `internal/tui/app.go` — Embedded ToastManager, overlays toasts on content
- Wired toasts into existing flows:
  - Device deleted → success toast
  - Service stopped → success toast
  - Service restarted → info toast
  - Deploy success → success toast
  - Connection test → success/error toast
  - Device upgrade → success/error toast

### Toast System
- 4 levels: info (ℹ), success (✓), warn (⚠), error (✗)
- Auto-dismiss after 3 seconds (configurable per toast)
- Stacked vertically in top-right corner
- `tea.Tick`-based timer for dismissal
- Max width ~40 chars with text wrapping