### PR TITLE
fix: prioritize SSH agent for passphrase-protected keys

### DIFF
--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -33,7 +34,7 @@ type Client struct {
 }
 
 // Connect establishes an SSH connection using the provided config.
-// Auth resolution order: explicit key → SSH agent → default keys → password.
+// Auth resolution order: SSH agent → explicit key → default keys → password.
 func Connect(cfg ClientConfig) (*Client, error) {
 	if cfg.Port == "" {
 		cfg.Port = "22"
@@ -169,19 +170,27 @@ func (c *Client) Underlying() *ssh.Client {
 }
 
 // resolveAuth builds auth methods in priority order.
+// SSH agent is tried first because it likely already holds unlocked keys,
+// which avoids passphrase prompts for encrypted private keys.
 func resolveAuth(cfg ClientConfig) ([]ssh.AuthMethod, error) {
 	var methods []ssh.AuthMethod
 
-	// 1. Explicit key path
-	if cfg.KeyPath != "" {
-		if m, err := keyAuth(expandPath(cfg.KeyPath), cfg.KeyPassphrase); err == nil {
-			methods = append(methods, m)
-		}
-	}
-
-	// 2. SSH agent
+	// 1. SSH agent (highest priority — handles passphrase-protected keys transparently)
 	if m, err := agentAuth(); err == nil {
 		methods = append(methods, m)
+	}
+
+	// 2. Explicit key path
+	if cfg.KeyPath != "" {
+		m, err := keyAuth(expandPath(cfg.KeyPath), cfg.KeyPassphrase)
+		if err != nil {
+			var passErr *ssh.PassphraseMissingError
+			if errors.As(err, &passErr) {
+				log.Printf("SSH key %s is encrypted with a passphrase; skipping (add it to ssh-agent with ssh-add)", cfg.KeyPath)
+			}
+		} else {
+			methods = append(methods, m)
+		}
 	}
 
 	// 3. Default key paths
@@ -194,9 +203,15 @@ func resolveAuth(cfg ClientConfig) ([]ssh.AuthMethod, error) {
 		if p == expandPath(cfg.KeyPath) {
 			continue // already tried
 		}
-		if m, err := keyAuth(p, ""); err == nil {
-			methods = append(methods, m)
+		m, err := keyAuth(p, "")
+		if err != nil {
+			var passErr *ssh.PassphraseMissingError
+			if errors.As(err, &passErr) {
+				log.Printf("SSH key %s is encrypted with a passphrase; skipping (add it to ssh-agent with ssh-add)", k)
+			}
+			continue
 		}
+		methods = append(methods, m)
 	}
 
 	// 4. Password
@@ -205,7 +220,7 @@ func resolveAuth(cfg ClientConfig) ([]ssh.AuthMethod, error) {
 	}
 
 	if len(methods) == 0 {
-		return nil, fmt.Errorf("no SSH auth methods available")
+		return nil, fmt.Errorf("no SSH auth methods available (if your key is passphrase-protected, use ssh-agent: eval $(ssh-agent) && ssh-add)")
 	}
 
 	return methods, nil

--- a/internal/tui/views/devices.go
+++ b/internal/tui/views/devices.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -187,10 +188,14 @@ func (dm *DeviceManager) testConnection(device config.Device) tea.Cmd {
 			KeyPath: device.SSHKey,
 		})
 		if err != nil {
+			hint := "SSH connection failed: " + err.Error()
+			if strings.Contains(err.Error(), "no SSH auth methods available") || strings.Contains(err.Error(), "unable to authenticate") {
+				hint += " (hint: if your key is passphrase-protected, make sure ssh-agent is running and your key is loaded via ssh-add)"
+			}
 			return connectionTestResult{
 				deviceID: device.ID,
 				online:   false,
-				err:      fmt.Errorf("SSH connection failed: %w", err),
+				err:      fmt.Errorf("%s", hint),
 			}
 		}
 		defer func() {


### PR DESCRIPTION
## Problem
When Yokai discovers SSH hosts from ~/.ssh/config and tries to connect, it fails silently if the SSH key is password-protected. The auth resolution tried parsing keys before checking the SSH agent, so encrypted keys would fail and get skipped.

## Fix
- **SSH agent is now first priority** in auth resolution (before explicit key path), matching standard OpenSSH behavior. The agent likely already holds the unlocked key via `ssh-add`.
- When `ParsePrivateKey` fails with a passphrase error, logs a helpful message suggesting `ssh-add` instead of silently skipping.
- Enhanced test-connection failure message in the TUI to hint about ssh-agent when auth fails.

## Testing
Tested with `darkporgs` (port 53663, user sbull, passphrase-protected key). Connection succeeds via SSH agent.