### PR TITLE
feat: comprehensive CLI interface for agent/script automation

### DIFF
--- a/cmd/yokai/main.go
+++ b/cmd/yokai/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spencerbull/yokai/internal/agent"
+	"github.com/spencerbull/yokai/internal/cli"
 	"github.com/spencerbull/yokai/internal/daemon"
 	"github.com/spencerbull/yokai/internal/tui"
 	"github.com/spencerbull/yokai/internal/upgrade"
@@ -33,6 +34,24 @@ func main() {
 				os.Exit(1)
 			}
 			return
+
+		// CLI commands (non-TUI)
+		case "devices":
+			cli.RunDevices(os.Args[2:])
+			return
+		case "services":
+			cli.RunServices(os.Args[2:])
+			return
+		case "status":
+			cli.RunStatus(os.Args[2:])
+			return
+		case "metrics":
+			cli.RunMetrics(os.Args[2:])
+			return
+		case "config":
+			cli.RunConfig(os.Args[2:])
+			return
+
 		case "--help", "-h":
 			printUsage()
 			return
@@ -68,10 +87,35 @@ func printUsage() {
 	fmt.Printf(`yokai %s — GPU Fleet Manager
 
 Usage:
-  yokai              Launch the TUI (default)
-  yokai agent [port] Run the agent on a target device (default port: 7474)
-  yokai daemon       Run the local background daemon
-  yokai upgrade      Update to the latest version
-  yokai version      Print version
+  yokai                    Launch the TUI (default)
+  yokai agent [port]       Run the agent on a target device (default port: 7474)
+  yokai daemon             Run the local background daemon
+  yokai upgrade            Update to the latest version
+  yokai version            Print version
+
+Device Management:
+  yokai devices list                         List all configured devices
+  yokai devices add --host <host> [flags]    Add a device
+  yokai devices remove <device-id>           Remove a device
+  yokai devices test <device-id>             Test SSH + agent connectivity
+  yokai devices bootstrap <device-id>        Install/upgrade agent on device
+
+Service Management:
+  yokai services list [--device <id>]        List containers across fleet
+  yokai services deploy --device <id> [flags] Deploy a service
+  yokai services stop <device-id> <cid>      Stop a container
+  yokai services restart <device-id> <cid>   Restart a container
+  yokai services logs [--follow] <did> <cid> Stream container logs
+
+Fleet Status:
+  yokai status                               Fleet overview (JSON)
+  yokai metrics [--device <id>]              Detailed device metrics (JSON)
+
+Configuration:
+  yokai config show                          Dump config (tokens redacted)
+  yokai config set <key> <value>             Set a config value
+  yokai config path                          Print config file path
+
+All CLI commands output JSON to stdout. Errors go to stderr as JSON.
 `, version)
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+// daemonClient talks to the local yokai daemon API.
+type daemonClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+func newDaemonClient(cfg *config.Config) *daemonClient {
+	addr := cfg.Daemon.Listen
+	if addr == "" {
+		addr = "127.0.0.1:7473"
+	}
+	return &daemonClient{
+		baseURL: "http://" + addr,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *daemonClient) get(path string) (json.RawMessage, error) {
+	resp, err := c.http.Get(c.baseURL + path)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable (is 'yokai daemon' running?): %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(body, &errResp) == nil && (errResp.Error != "" || errResp.Message != "") {
+			msg := errResp.Error
+			if errResp.Message != "" {
+				msg = errResp.Message
+			}
+			return nil, fmt.Errorf("%s", msg)
+		}
+		return nil, fmt.Errorf("daemon returned status %d", resp.StatusCode)
+	}
+
+	return json.RawMessage(body), nil
+}
+
+func (c *daemonClient) post(path string, body io.Reader) (json.RawMessage, error) {
+	resp, err := c.http.Post(c.baseURL+path, "application/json", body)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable (is 'yokai daemon' running?): %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errResp struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(respBody, &errResp) == nil && (errResp.Error != "" || errResp.Message != "") {
+			msg := errResp.Error
+			if errResp.Message != "" {
+				msg = errResp.Message
+			}
+			return nil, fmt.Errorf("%s", msg)
+		}
+		return nil, fmt.Errorf("daemon returned status %d", resp.StatusCode)
+	}
+
+	return json.RawMessage(respBody), nil
+}
+
+// getSSE connects to an SSE endpoint and sends lines to a channel.
+// The caller should close the returned channel by cancelling the request context.
+func (c *daemonClient) getSSE(path string) (<-chan string, error) {
+	req, err := http.NewRequest("GET", c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	// Use a client with no timeout for streaming
+	streamClient := &http.Client{}
+	resp, err := streamClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("log stream failed with status %d", resp.StatusCode)
+	}
+
+	ch := make(chan string, 100)
+	go func() {
+		defer func() { _ = resp.Body.Close() }()
+		defer close(ch)
+
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				// Parse SSE lines
+				data := string(buf[:n])
+				for _, line := range splitLines(data) {
+					if len(line) > 6 && line[:6] == "data: " {
+						ch <- line[6:]
+					} else if line != "" {
+						ch <- line
+					}
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			line := s[start:i]
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+			lines = append(lines, line)
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+// RunConfig dispatches config subcommands.
+func RunConfig(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: yokai config <show|set|path>")
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "show":
+		runConfigShow()
+	case "set":
+		runConfigSet(args[1:])
+	case "path":
+		runConfigPath()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown config command: %s\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func runConfigShow() {
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	// Redact sensitive values
+	redacted := *cfg
+	if redacted.HFToken != "" {
+		redacted.HFToken = redacted.HFToken[:4] + "..." + redacted.HFToken[len(redacted.HFToken)-4:]
+	}
+	for i := range redacted.Devices {
+		if redacted.Devices[i].AgentToken != "" {
+			t := redacted.Devices[i].AgentToken
+			redacted.Devices[i].AgentToken = t[:4] + "..." + t[len(t)-4:]
+		}
+	}
+
+	outputJSON(redacted)
+}
+
+func runConfigSet(args []string) {
+	if len(args) < 2 {
+		exitError("Usage: yokai config set <key> <value>")
+	}
+	key := args[0]
+	value := args[1]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	switch strings.ToLower(key) {
+	case "hf_token":
+		cfg.HFToken = value
+	case "daemon.listen":
+		cfg.Daemon.Listen = value
+	case "daemon.metrics_poll_interval":
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			exitError(fmt.Sprintf("invalid integer: %s", value))
+		}
+		cfg.Daemon.MetricsPollInterval = n
+	case "daemon.reconnect_interval":
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			exitError(fmt.Sprintf("invalid integer: %s", value))
+		}
+		cfg.Daemon.ReconnectInterval = n
+	case "preferences.theme":
+		cfg.Preferences.Theme = value
+	case "preferences.default_vllm_image":
+		cfg.Preferences.DefaultVLLMImage = value
+	case "preferences.default_llama_image":
+		cfg.Preferences.DefaultLlamaImage = value
+	case "preferences.default_comfyui_image":
+		cfg.Preferences.DefaultComfyImage = value
+	default:
+		exitError(fmt.Sprintf("unknown config key: %s\nValid keys: hf_token, daemon.listen, daemon.metrics_poll_interval, daemon.reconnect_interval, preferences.theme, preferences.default_vllm_image, preferences.default_llama_image, preferences.default_comfyui_image", key))
+	}
+
+	if err := config.Save(cfg); err != nil {
+		exitError(fmt.Sprintf("saving config: %v", err))
+	}
+
+	// Show the raw value that was set
+	var raw json.RawMessage
+	raw, _ = json.Marshal(value)
+
+	outputJSON(map[string]interface{}{
+		"status": "updated",
+		"key":    key,
+		"value":  json.RawMessage(raw),
+	})
+}
+
+func runConfigPath() {
+	path, err := config.ConfigPath()
+	if err != nil {
+		exitError(fmt.Sprintf("getting config path: %v", err))
+	}
+	outputJSON(map[string]string{"path": path})
+}

--- a/internal/cli/devices.go
+++ b/internal/cli/devices.go
@@ -1,0 +1,334 @@
+package cli
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/spencerbull/yokai/internal/config"
+	sshpkg "github.com/spencerbull/yokai/internal/ssh"
+)
+
+// RunDevices dispatches devices subcommands.
+func RunDevices(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: yokai devices <list|add|remove|test|bootstrap>")
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "list":
+		runDevicesList(args[1:])
+	case "add":
+		runDevicesAdd(args[1:])
+	case "remove":
+		runDevicesRemove(args[1:])
+	case "test":
+		runDevicesTest(args[1:])
+	case "bootstrap":
+		runDevicesBootstrap(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown devices command: %s\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func runDevicesList(_ []string) {
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+	data, err := client.get("/devices")
+	if err != nil {
+		// Fall back to config-only listing if daemon is unavailable
+		type deviceInfo struct {
+			config.Device
+			Online bool `json:"online"`
+		}
+		var devices []deviceInfo
+		for _, d := range cfg.Devices {
+			devices = append(devices, deviceInfo{Device: d, Online: false})
+		}
+		if devices == nil {
+			devices = []deviceInfo{}
+		}
+		outputJSON(map[string]interface{}{"devices": devices, "source": "config"})
+		return
+	}
+
+	outputRaw(data)
+}
+
+func runDevicesAdd(args []string) {
+	fs := flag.NewFlagSet("yokai devices add", flag.ExitOnError)
+	host := fs.String("host", "", "Hostname or IP address (required)")
+	label := fs.String("label", "", "Human-readable label")
+	sshUser := fs.String("ssh-user", "root", "SSH user")
+	sshKey := fs.String("ssh-key", "", "Path to SSH private key")
+	sshPort := fs.Int("ssh-port", 22, "SSH port")
+	connType := fs.String("type", "manual", "Connection type: tailscale, local, manual")
+	agentPort := fs.Int("agent-port", 7474, "Agent port on remote device")
+	agentToken := fs.String("agent-token", "", "Agent auth token")
+	gpuType := fs.String("gpu-type", "", "GPU type: nvidia, amd, apple")
+	_ = fs.Parse(args)
+
+	if *host == "" {
+		exitError("--host is required")
+	}
+
+	if *label == "" {
+		*label = *host
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	// Check for duplicate
+	if cfg.FindDevice(*host) != nil {
+		exitError(fmt.Sprintf("device %q already exists", *host))
+	}
+
+	device := config.Device{
+		ID:             *host,
+		Label:          *label,
+		Host:           *host,
+		SSHUser:        *sshUser,
+		SSHKey:         *sshKey,
+		SSHPort:        *sshPort,
+		ConnectionType: *connType,
+		AgentPort:      *agentPort,
+		AgentToken:     *agentToken,
+		GPUType:        *gpuType,
+	}
+
+	cfg.AddDevice(device)
+	if err := config.Save(cfg); err != nil {
+		exitError(fmt.Sprintf("saving config: %v", err))
+	}
+
+	// Notify daemon to reload
+	reloadDaemon(cfg)
+
+	outputJSON(map[string]interface{}{
+		"status": "added",
+		"device": device,
+	})
+}
+
+func runDevicesRemove(args []string) {
+	if len(args) == 0 {
+		exitError("Usage: yokai devices remove <device-id>")
+	}
+	deviceID := args[0]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	// Find by ID or label
+	found := cfg.FindDevice(deviceID)
+	if found == nil {
+		// Try finding by label
+		for i := range cfg.Devices {
+			if cfg.Devices[i].Label == deviceID {
+				found = &cfg.Devices[i]
+				break
+			}
+		}
+	}
+
+	if found == nil {
+		exitError(fmt.Sprintf("device %q not found", deviceID))
+	}
+
+	actualID := found.ID
+	cfg.RemoveDevice(actualID)
+	if err := config.Save(cfg); err != nil {
+		exitError(fmt.Sprintf("saving config: %v", err))
+	}
+
+	reloadDaemon(cfg)
+
+	outputJSON(map[string]string{
+		"status":    "removed",
+		"device_id": actualID,
+	})
+}
+
+func runDevicesTest(args []string) {
+	if len(args) == 0 {
+		exitError("Usage: yokai devices test <device-id>")
+	}
+	deviceID := args[0]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	dev := cfg.FindDevice(deviceID)
+	if dev == nil {
+		// Try label
+		for i := range cfg.Devices {
+			if cfg.Devices[i].Label == deviceID {
+				dev = &cfg.Devices[i]
+				break
+			}
+		}
+	}
+	if dev == nil {
+		exitError(fmt.Sprintf("device %q not found in config", deviceID))
+	}
+
+	result := map[string]interface{}{
+		"device_id": dev.ID,
+		"host":      dev.Host,
+	}
+
+	// Test SSH
+	client, err := sshpkg.Connect(sshpkg.ClientConfig{
+		Host:    dev.Host,
+		Port:    strconv.Itoa(dev.SSHPortOrDefault()),
+		User:    dev.SSHUser,
+		KeyPath: dev.SSHKey,
+	})
+	if err != nil {
+		result["ssh"] = map[string]interface{}{"ok": false, "error": err.Error()}
+		result["agent"] = map[string]interface{}{"ok": false, "error": "skipped (SSH failed)"}
+		outputJSON(result)
+		os.Exit(1)
+	}
+	defer func() { _ = client.Close() }()
+	result["ssh"] = map[string]interface{}{"ok": true}
+
+	// Test agent via daemon tunnel if available
+	daemonClient := newDaemonClient(cfg)
+	data, err := daemonClient.get(fmt.Sprintf("/metrics/%s", dev.ID))
+	if err != nil {
+		// Try direct SSH check for agent
+		out, execErr := client.Exec("curl -sf http://localhost:" + strconv.Itoa(dev.AgentPort) + "/health 2>/dev/null || echo AGENT_UNREACHABLE")
+		if execErr != nil || out == "AGENT_UNREACHABLE\n" || out == "AGENT_UNREACHABLE" {
+			result["agent"] = map[string]interface{}{"ok": false, "error": "agent not responding on port " + strconv.Itoa(dev.AgentPort)}
+		} else {
+			result["agent"] = map[string]interface{}{"ok": true, "method": "ssh_direct"}
+		}
+	} else {
+		_ = data
+		result["agent"] = map[string]interface{}{"ok": true, "method": "daemon_tunnel"}
+	}
+
+	outputJSON(result)
+}
+
+func runDevicesBootstrap(args []string) {
+	if len(args) == 0 {
+		exitError("Usage: yokai devices bootstrap <device-id>")
+	}
+	deviceID := args[0]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	dev := cfg.FindDevice(deviceID)
+	if dev == nil {
+		for i := range cfg.Devices {
+			if cfg.Devices[i].Label == deviceID {
+				dev = &cfg.Devices[i]
+				break
+			}
+		}
+	}
+	if dev == nil {
+		exitError(fmt.Sprintf("device %q not found in config", deviceID))
+	}
+
+	// Connect via SSH
+	client, err := sshpkg.Connect(sshpkg.ClientConfig{
+		Host:    dev.Host,
+		Port:    strconv.Itoa(dev.SSHPortOrDefault()),
+		User:    dev.SSHUser,
+		KeyPath: dev.SSHKey,
+	})
+	if err != nil {
+		exitError(fmt.Sprintf("SSH connect failed: %v", err))
+	}
+	defer func() { _ = client.Close() }()
+
+	// Preflight
+	pf, err := sshpkg.Preflight(client)
+	if err != nil {
+		exitError(fmt.Sprintf("pre-flight failed: %v", err))
+	}
+	if !pf.DockerInstalled {
+		exitError(fmt.Sprintf("docker not installed on %s", dev.Host))
+	}
+
+	// Generate agent token
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		exitError(fmt.Sprintf("generating token: %v", err))
+	}
+	agentToken := hex.EncodeToString(tokenBytes)
+
+	// Get binary path
+	binaryPath, err := os.Executable()
+	if err != nil {
+		exitError(fmt.Sprintf("getting binary path: %v", err))
+	}
+
+	// Deploy agent
+	if err := sshpkg.DeployAgent(client, binaryPath, agentToken); err != nil {
+		exitError(fmt.Sprintf("deploying agent: %v", err))
+	}
+
+	// Update device config with token and GPU info
+	dev.AgentToken = agentToken
+	if pf.GPUDetected {
+		dev.GPUType = "nvidia"
+	}
+	if err := config.Save(cfg); err != nil {
+		exitError(fmt.Sprintf("saving config: %v", err))
+	}
+
+	reloadDaemon(cfg)
+
+	outputJSON(map[string]interface{}{
+		"status":    "bootstrapped",
+		"device_id": dev.ID,
+		"preflight": map[string]interface{}{
+			"os":              pf.OS,
+			"arch":            pf.Arch,
+			"docker_version":  pf.DockerVersion,
+			"gpu_detected":    pf.GPUDetected,
+			"gpu_name":        pf.GPUName,
+			"gpu_vram_mb":     pf.GPUVRAMMb,
+			"nvidia_toolkit":  pf.NvidiaToolkitInstalled,
+			"nvidia_runtime":  pf.NvidiaRuntimeAvailable,
+			"disk_free_gb":    pf.DiskFreeGB,
+		},
+	})
+}
+
+// reloadDaemon tells the daemon to reload config. Best-effort.
+func reloadDaemon(cfg *config.Config) {
+	addr := cfg.Daemon.Listen
+	if addr == "" {
+		addr = "127.0.0.1:7473"
+	}
+	resp, err := http.Post("http://"+addr+"/reload", "application/json", nil)
+	if err != nil {
+		return // daemon may not be running
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// outputJSON writes a JSON value to stdout, pretty-printed.
+func outputJSON(v interface{}) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		exitError(fmt.Sprintf("encoding output: %v", err))
+	}
+}
+
+// outputRaw writes raw JSON bytes to stdout (already formatted from daemon).
+func outputRaw(data json.RawMessage) {
+	// Re-indent for consistent formatting
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		// Fall back to raw output
+		_, _ = fmt.Fprintln(os.Stdout, string(data))
+		return
+	}
+	outputJSON(v)
+}
+
+// exitError writes a JSON error to stderr and exits with code 1.
+func exitError(msg string) {
+	enc := json.NewEncoder(os.Stderr)
+	_ = enc.Encode(map[string]string{"error": msg})
+	os.Exit(1)
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+// RunServices dispatches services subcommands.
+func RunServices(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: yokai services <list|deploy|stop|restart|logs>")
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "list":
+		runServicesList(args[1:])
+	case "deploy":
+		runServicesDeploy(args[1:])
+	case "stop":
+		runServicesStop(args[1:])
+	case "restart":
+		runServicesRestart(args[1:])
+	case "logs":
+		runServicesLogs(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown services command: %s\n", args[0])
+		os.Exit(1)
+	}
+}
+
+func runServicesList(args []string) {
+	fs := flag.NewFlagSet("yokai services list", flag.ExitOnError)
+	deviceFilter := fs.String("device", "", "Filter by device ID")
+	_ = fs.Parse(args)
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+
+	// Get all metrics which include container info
+	data, err := client.get("/metrics")
+	if err != nil {
+		exitError(fmt.Sprintf("fetching metrics: %v", err))
+	}
+
+	// Parse and filter
+	var allMetrics map[string]json.RawMessage
+	if err := json.Unmarshal(data, &allMetrics); err != nil {
+		exitError(fmt.Sprintf("parsing metrics: %v", err))
+	}
+
+	type containerInfo struct {
+		DeviceID   string          `json:"device_id"`
+		Containers json.RawMessage `json:"containers"`
+	}
+
+	var result []containerInfo
+	for deviceID, metrics := range allMetrics {
+		if *deviceFilter != "" && deviceID != *deviceFilter {
+			continue
+		}
+		var m struct {
+			Containers json.RawMessage `json:"containers"`
+		}
+		if err := json.Unmarshal(metrics, &m); err != nil {
+			continue
+		}
+		result = append(result, containerInfo{
+			DeviceID:   deviceID,
+			Containers: m.Containers,
+		})
+	}
+
+	if result == nil {
+		result = []containerInfo{}
+	}
+
+	outputJSON(map[string]interface{}{"services": result})
+}
+
+func runServicesDeploy(args []string) {
+	fs := flag.NewFlagSet("yokai services deploy", flag.ExitOnError)
+	deviceID := fs.String("device", "", "Device ID (required)")
+	serviceType := fs.String("type", "", "Service type: vllm, llamacpp, comfyui")
+	model := fs.String("model", "", "Model name/path")
+	port := fs.String("port", "", "Port mapping (e.g. 8000:8000)")
+	image := fs.String("image", "", "Docker image (auto-selected if omitted)")
+	name := fs.String("name", "", "Container name")
+	extraArgs := fs.String("extra-args", "", "Extra docker arguments")
+	gpuIDs := fs.String("gpu-ids", "all", "GPU IDs to use")
+	_ = fs.Parse(args)
+
+	if *deviceID == "" {
+		exitError("--device is required")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	// Auto-select image based on type if not provided
+	if *image == "" && *serviceType != "" {
+		switch *serviceType {
+		case "vllm":
+			*image = cfg.Preferences.DefaultVLLMImage
+		case "llamacpp":
+			*image = cfg.Preferences.DefaultLlamaImage
+		case "comfyui":
+			*image = cfg.Preferences.DefaultComfyImage
+		}
+	}
+
+	if *image == "" {
+		exitError("--image or --type is required")
+	}
+
+	// Build port mapping
+	ports := make(map[string]string)
+	if *port != "" {
+		// Parse "host:container" format
+		ports = parsePortMapping(*port, *serviceType)
+	} else if *serviceType != "" {
+		// Default ports based on service type
+		switch *serviceType {
+		case "vllm":
+			ports["8000"] = "8000"
+		case "llamacpp":
+			ports["8080"] = "8080"
+		case "comfyui":
+			ports["8188"] = "8188"
+		}
+	}
+
+	// Container name
+	if *name == "" && *serviceType != "" {
+		*name = "yokai-" + *serviceType
+	}
+
+	deployReq := map[string]interface{}{
+		"device_id":  *deviceID,
+		"image":      *image,
+		"name":       *name,
+		"model":      *model,
+		"ports":      ports,
+		"gpu_ids":    *gpuIDs,
+		"extra_args": *extraArgs,
+	}
+
+	body, _ := json.Marshal(deployReq)
+	client := newDaemonClient(cfg)
+	data, err := client.post("/deploy", bytes.NewReader(body))
+	if err != nil {
+		exitError(fmt.Sprintf("deploy failed: %v", err))
+	}
+
+	outputRaw(data)
+}
+
+func runServicesStop(args []string) {
+	if len(args) < 2 {
+		exitError("Usage: yokai services stop <device-id> <container-id>")
+	}
+	deviceID := args[0]
+	containerID := args[1]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+	data, err := client.post(fmt.Sprintf("/containers/%s/%s/stop", deviceID, containerID), nil)
+	if err != nil {
+		exitError(fmt.Sprintf("stop failed: %v", err))
+	}
+
+	outputRaw(data)
+}
+
+func runServicesRestart(args []string) {
+	if len(args) < 2 {
+		exitError("Usage: yokai services restart <device-id> <container-id>")
+	}
+	deviceID := args[0]
+	containerID := args[1]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+	data, err := client.post(fmt.Sprintf("/containers/%s/%s/restart", deviceID, containerID), nil)
+	if err != nil {
+		exitError(fmt.Sprintf("restart failed: %v", err))
+	}
+
+	outputRaw(data)
+}
+
+func runServicesLogs(args []string) {
+	fs := flag.NewFlagSet("yokai services logs", flag.ExitOnError)
+	follow := fs.Bool("follow", false, "Follow log output")
+	_ = fs.Parse(args)
+
+	remaining := fs.Args()
+	if len(remaining) < 2 {
+		exitError("Usage: yokai services logs [--follow] <device-id> <container-id>")
+	}
+	deviceID := remaining[0]
+	containerID := remaining[1]
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+
+	if *follow {
+		// Stream logs via SSE
+		ch, err := client.getSSE(fmt.Sprintf("/logs/%s/%s", deviceID, containerID))
+		if err != nil {
+			exitError(fmt.Sprintf("streaming logs: %v", err))
+		}
+		for line := range ch {
+			fmt.Println(line)
+		}
+	} else {
+		// Get snapshot of logs via SSE, read what's available
+		ch, err := client.getSSE(fmt.Sprintf("/logs/%s/%s", deviceID, containerID))
+		if err != nil {
+			exitError(fmt.Sprintf("fetching logs: %v", err))
+		}
+		for line := range ch {
+			fmt.Println(line)
+		}
+	}
+}
+
+// parsePortMapping parses "host:container" or just "port" into a map.
+func parsePortMapping(spec string, serviceType string) map[string]string {
+	ports := make(map[string]string)
+	// Simple "host:container" parsing
+	for i := 0; i < len(spec); i++ {
+		if spec[i] == ':' {
+			ports[spec[i+1:]] = spec[:i]
+			return ports
+		}
+	}
+	// Single port: use as both
+	ports[spec] = spec
+	return ports
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+// RunStatus outputs fleet overview.
+func RunStatus(_ []string) {
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+
+	// Get devices
+	devicesData, err := client.get("/devices")
+	if err != nil {
+		exitError(fmt.Sprintf("fetching devices: %v", err))
+	}
+
+	// Get metrics
+	metricsData, err := client.get("/metrics")
+	if err != nil {
+		exitError(fmt.Sprintf("fetching metrics: %v", err))
+	}
+
+	// Parse devices
+	var devicesResp struct {
+		Devices []json.RawMessage `json:"devices"`
+	}
+	if err := json.Unmarshal(devicesData, &devicesResp); err != nil {
+		exitError(fmt.Sprintf("parsing devices: %v", err))
+	}
+
+	// Count online/offline
+	online := 0
+	offline := 0
+	for _, d := range devicesResp.Devices {
+		var dev struct {
+			Online bool `json:"online"`
+		}
+		if json.Unmarshal(d, &dev) == nil {
+			if dev.Online {
+				online++
+			} else {
+				offline++
+			}
+		}
+	}
+
+	// Count containers and GPU usage from metrics
+	var allMetrics map[string]json.RawMessage
+	containerCount := 0
+	if json.Unmarshal(metricsData, &allMetrics) == nil {
+		for _, m := range allMetrics {
+			var metrics struct {
+				Containers json.RawMessage `json:"containers"`
+			}
+			if json.Unmarshal(m, &metrics) == nil && len(metrics.Containers) > 2 {
+				var containers []json.RawMessage
+				if json.Unmarshal(metrics.Containers, &containers) == nil {
+					containerCount += len(containers)
+				}
+			}
+		}
+	}
+
+	outputJSON(map[string]interface{}{
+		"devices_total":   len(devicesResp.Devices),
+		"devices_online":  online,
+		"devices_offline": offline,
+		"containers":      containerCount,
+		"devices":         devicesResp.Devices,
+		"metrics":         allMetrics,
+	})
+}
+
+// RunMetrics outputs detailed metrics.
+func RunMetrics(args []string) {
+	fs := flag.NewFlagSet("yokai metrics", flag.ExitOnError)
+	deviceID := fs.String("device", "", "Filter by device ID")
+	_ = fs.Parse(args)
+
+	cfg, err := config.Load()
+	if err != nil {
+		exitError(fmt.Sprintf("loading config: %v", err))
+	}
+
+	client := newDaemonClient(cfg)
+
+	if *deviceID != "" {
+		data, err := client.get(fmt.Sprintf("/metrics/%s", *deviceID))
+		if err != nil {
+			exitError(fmt.Sprintf("fetching metrics for %s: %v", *deviceID, err))
+		}
+		outputRaw(data)
+	} else {
+		data, err := client.get("/metrics")
+		if err != nil {
+			exitError(fmt.Sprintf("fetching metrics: %v", err))
+		}
+		outputRaw(data)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a full CLI interface so AI agents and scripts can use all Yokai functionality without the TUI.

## New Commands

### Device Management
```
yokai devices list                    # JSON list of all devices + status
yokai devices add --host X --label Y  # Add device non-interactively
yokai devices remove <id>             # Remove device by ID or label
yokai devices test <id>               # Test SSH + agent connectivity
yokai devices bootstrap <id>          # Install/upgrade agent on remote
```

### Service Management
```
yokai services list [--device <id>]   # List containers across fleet
yokai services deploy --device <id> --type vllm --model X --port 8000
yokai services stop <device> <container>
yokai services restart <device> <container>
yokai services logs <device> <container> [--follow]
```

### Fleet Status
```
yokai status                          # Fleet overview (JSON)
yokai metrics [--device <id>]         # Detailed CPU/RAM/GPU/disk metrics
```

### Config
```
yokai config show                     # Dump config (tokens redacted)
yokai config set <key> <value>        # Set a config value
yokai config path                     # Print config file path
```

## Design
- **All JSON output** to stdout for agent consumption
- **Errors** as JSON to stderr with proper exit codes
- **Daemon-first**: live data commands talk to daemon REST API
- **Config-direct**: offline commands operate on config.json directly
- **No new dependencies**: stdlib `flag` package, manual subcommand routing
- **1064 lines added** across 6 new files in `internal/cli/`

## Files
- `internal/cli/client.go` — daemon HTTP client
- `internal/cli/output.go` — JSON output helpers
- `internal/cli/devices.go` — device subcommands
- `internal/cli/services.go` — service subcommands
- `internal/cli/status.go` — status + metrics
- `internal/cli/config.go` — config subcommands
- `cmd/yokai/main.go` — subcommand routing