### PR TITLE
fix: prompt for passphrase when SSH config key is encrypted

### DIFF
--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -256,6 +256,22 @@ func agentAuth() (ssh.AuthMethod, error) {
 	return ssh.PublicKeysCallback(agentClient.Signers), nil
 }
 
+// IsKeyEncrypted checks whether an SSH private key file is passphrase-protected.
+// Returns true if the key exists and requires a passphrase to decrypt.
+func IsKeyEncrypted(path string) bool {
+	path = expandPath(path)
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	_, err = ssh.ParsePrivateKey(key)
+	if err != nil {
+		var passErr *ssh.PassphraseMissingError
+		return errors.As(err, &passErr)
+	}
+	return false
+}
+
 func expandPath(path string) string {
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()

--- a/internal/tui/views/sshconfig.go
+++ b/internal/tui/views/sshconfig.go
@@ -84,6 +84,16 @@ func (p *SSHConfigPicker) handleSelect() tea.Cmd {
 			user = "root"
 		}
 
+		// If the key is passphrase-protected, route through the credentials
+		// view so the user can enter the passphrase.
+		if h.IdentityFile != "" && sshpkg.IsKeyEncrypted(h.IdentityFile) {
+			return Navigate(NewSSHCredsFromConfig(
+				p.cfg, p.version,
+				host, h.Alias, "ssh-config",
+				user, h.IdentityFile, sshPort,
+			))
+		}
+
 		return Navigate(NewBootstrap(
 			p.cfg, p.version,
 			host, h.Alias, "ssh-config",

--- a/internal/tui/views/sshcreds.go
+++ b/internal/tui/views/sshcreds.go
@@ -86,6 +86,39 @@ func NewSSHCreds(cfg *config.Config, version string, host, label, connType strin
 	return s
 }
 
+// NewSSHCredsFromConfig creates the SSH credentials view pre-filled with values
+// discovered from ~/.ssh/config. It pre-selects "Key File" auth and focuses the
+// passphrase field since the key is known to be encrypted.
+func NewSSHCredsFromConfig(cfg *config.Config, version string, host, label, connType, user, keyPath string, sshPort int) *SSHCreds {
+	if label == "" {
+		label = host
+	}
+
+	s := &SSHCreds{
+		cfg:            cfg,
+		version:        version,
+		host:           host,
+		label:          label,
+		connectionType: connType,
+		auth:           authKeyFile,
+		activeField:    fieldKeyPassphrase,
+	}
+
+	s.userInput = components.NewTextField("username")
+	s.userInput.SetValue(user)
+
+	s.sshPortInput = components.NewPortField(fmt.Sprintf("%d", sshPort))
+
+	s.keyPathInput = components.NewTextField("~/.ssh/id_ed25519")
+	s.keyPathInput.SetValue(keyPath)
+
+	s.keyPassphraseInput = components.NewPasswordField("key passphrase (required)")
+	s.keyPassphraseInput.Focus()
+	s.passwordInput = components.NewPasswordField("password")
+
+	return s
+}
+
 func (s *SSHCreds) Init() tea.Cmd {
 	return textinput.Blink
 }


### PR DESCRIPTION
## Problem
When selecting a host from SSH config discovery (e.g. darkporgs), if the identity file is passphrase-protected and the SSH agent doesn't have the key loaded, Yokai goes straight to Bootstrap and fails with:

```
SSH dial darkporgs:53663: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

The key is skipped with a log message but no way for the user to enter the passphrase.

## Fix
- **Detect encrypted keys** before starting bootstrap — new `IsKeyEncrypted()` helper tries `ParsePrivateKey` and checks for `PassphraseMissingError`
- **Route to SSH credentials view** when an encrypted key is detected — pre-filled with all SSH config values (user, port, key path), focused on the passphrase field
- User enters passphrase → proceeds to bootstrap with the passphrase included

## Flow
```
SSH Config Picker → detect encrypted key → SSHCreds (pre-filled, passphrase focused) → Bootstrap
                  → key not encrypted   → Bootstrap (direct, as before)
```

## Testing
Select darkporgs from SSH Config — should now show the credentials view with passphrase field focused instead of immediately failing.