### PR TITLE
feat: dashboard design overhaul — consistent grid, cleaner panels

### DIFF
--- a/internal/tui/components/devicecard.go
+++ b/internal/tui/components/devicecard.go
@@ -51,7 +51,7 @@ func (d DeviceCard) Render() string {
 		contentWidth = 10
 	}
 
-	// Title line: "My Server (192.168.1.100) ── ● online ──"
+	// Title line: "finn  ● online" (label left, status right-aligned)
 	statusDot := ""
 	statusText := ""
 	if d.Online {
@@ -62,54 +62,47 @@ func (d DeviceCard) Render() string {
 		statusText = "offline"
 	}
 
-	titlePart := fmt.Sprintf("%s (%s)", d.Label, d.Host)
+	titlePart := d.Label
 	statusPart := fmt.Sprintf("%s %s", statusDot, statusText)
 
-	// Calculate padding for title line (use visual width for styled text)
+	// Right-align status within content width
 	titleLen := lipgloss.Width(titlePart)
 	statusLen := lipgloss.Width(statusPart)
-	dashesNeeded := contentWidth - titleLen - statusLen - 6 // -6 for spaces and dash separators
-	if dashesNeeded < 0 {
-		dashesNeeded = 0
+	gap := contentWidth - titleLen - statusLen
+	if gap < 1 {
+		gap = 1
 	}
 
-	leftDashes := dashesNeeded / 2
-	rightDashes := dashesNeeded - leftDashes
+	title := titlePart + strings.Repeat(" ", gap) + statusPart
 
-	var title string
-	if dashesNeeded > 0 {
-		title = titlePart + " " + strings.Repeat("─", leftDashes+1) + " " + statusPart + " " + strings.Repeat("─", rightDashes)
-	} else {
-		// Not enough space for dashes, just use basic format
-		title = titlePart + " " + statusPart
-	}
-
-	// Truncate title if it's still too long (use visual width for styled content)
+	// Truncate title if still too long
 	if lipgloss.Width(title) > contentWidth {
-		// Rebuild with shorter titlePart to avoid cutting ANSI codes
-		maxTitleLen := contentWidth - statusLen - 4
+		maxTitleLen := contentWidth - statusLen - 2
 		if maxTitleLen > 3 {
 			titlePart = titlePart[:min(len(titlePart), maxTitleLen-3)] + "..."
-			title = titlePart + " " + statusPart
+			gap = contentWidth - lipgloss.Width(titlePart) - statusLen
+			if gap < 1 {
+				gap = 1
+			}
+			title = titlePart + strings.Repeat(" ", gap) + statusPart
 		}
 	}
 
-	// GPU line: "GPU: 2x NVIDIA RTX 4090"
+	// GPU line: show actual name like "RTX Pro 6000", fallback to type
 	gpuLine := ""
 	if d.GPUCount > 0 && d.GPUType != "" {
+		gpuDisplay := d.GPUType
+		// Strip common prefixes for cleaner display
+		gpuDisplay = strings.TrimPrefix(gpuDisplay, "NVIDIA ")
 		if d.GPUCount == 1 {
-			gpuLine = fmt.Sprintf("GPU: %s", d.GPUType)
+			gpuLine = fmt.Sprintf("GPU  %s", gpuDisplay)
 		} else {
-			gpuLine = fmt.Sprintf("GPU: %dx %s", d.GPUCount, d.GPUType)
+			gpuLine = fmt.Sprintf("GPU  %dx %s", d.GPUCount, gpuDisplay)
 		}
 	} else if d.GPUCount > 0 {
-		if d.GPUCount == 1 {
-			gpuLine = "GPU: 1 device"
-		} else {
-			gpuLine = fmt.Sprintf("GPU: %d devices", d.GPUCount)
-		}
+		gpuLine = fmt.Sprintf("GPU  %d device(s)", d.GPUCount)
 	} else {
-		gpuLine = "GPU: None"
+		gpuLine = "GPU  none"
 	}
 
 	// Metrics line: "CPU [████░░░░░░] 32%  RAM [██████░░] 67%"
@@ -136,15 +129,15 @@ func (d DeviceCard) Render() string {
 		cpuLabel, cpuBar, cpuPercentStr,
 		ramLabel, ramBar, ramPercentStr)
 
-	// Services line: "Services: 3 running"
+	// Services line
 	var servicesLine string
 	switch d.ServiceCount {
 	case 0:
-		servicesLine = "Services: None"
+		servicesLine = "Svc  none"
 	case 1:
-		servicesLine = "Services: 1 running"
+		servicesLine = "Svc  1 running"
 	default:
-		servicesLine = fmt.Sprintf("Services: %d running", d.ServiceCount)
+		servicesLine = fmt.Sprintf("Svc  %d running", d.ServiceCount)
 	}
 
 	// Truncate and pad lines to content width

--- a/internal/tui/components/gpupanel.go
+++ b/internal/tui/components/gpupanel.go
@@ -68,27 +68,15 @@ func (g GPUPanel) Render() string {
 		title = title[:contentWidth-9] + "..."
 	}
 
-	// Utilization bar with gradient
-	utilPercent := float64(g.UtilPercent)
-	utilBar := NewMetricsBar("Util", utilPercent, contentWidth/2)
-
-	// Temperature with color-coding
-	tColor := tempColor(g.TempC)
-	tempStyle := lipgloss.NewStyle().Foreground(tColor)
-	tempStr := tempStyle.Render(fmt.Sprintf("🌡 %d°C", g.TempC))
-
-	// Calculate spacing for util line using visual width (not byte length)
-	// to account for ANSI escape codes in styled strings
-	utilBarStr := utilBar.Render()
-	utilBarVisualWidth := lipgloss.Width(utilBarStr)
-	tempPlainLen := lipgloss.Width(tempStr)
-	utilLineSpacing := contentWidth - utilBarVisualWidth - tempPlainLen
-	if utilLineSpacing < 1 {
-		utilLineSpacing = 1
+	// Utilization bar — single line
+	utilBarWidth := contentWidth - len("Util ") - 5 // "Util [bar] XX%"
+	if utilBarWidth < 5 {
+		utilBarWidth = 5
 	}
-	utilLine := utilBarStr + strings.Repeat(" ", utilLineSpacing) + tempStr
+	utilBar := GradientProgressBar(float64(g.UtilPercent), utilBarWidth, theme.Accent)
+	utilLine := fmt.Sprintf("Util %s %3d%%", utilBar, g.UtilPercent)
 
-	// VRAM visualization with ntcharts bar chart
+	// VRAM bar — single line
 	vramPercent := float64(0)
 	if g.VRAMTotalMB > 0 {
 		vramPercent = float64(g.VRAMUsedMB) / float64(g.VRAMTotalMB) * 100
@@ -96,7 +84,6 @@ func (g GPUPanel) Render() string {
 	vramUsedGB := float64(g.VRAMUsedMB) / 1024
 	vramTotalGB := float64(g.VRAMTotalMB) / 1024
 
-	// Choose VRAM bar color based on usage
 	vramColor := theme.Good
 	if vramPercent > 80 {
 		vramColor = theme.Crit
@@ -104,7 +91,7 @@ func (g GPUPanel) Render() string {
 		vramColor = theme.Warn
 	}
 
-	vramLabel := fmt.Sprintf("%.0fGB/%.0fGB", vramUsedGB, vramTotalGB)
+	vramLabel := fmt.Sprintf("%.0fG/%.0fG", vramUsedGB, vramTotalGB)
 	vramBarWidth := contentWidth - len("VRAM ") - len(vramLabel) - 1
 	if vramBarWidth < 5 {
 		vramBarWidth = 5
@@ -112,7 +99,11 @@ func (g GPUPanel) Render() string {
 	vramBar := GradientProgressBar(vramPercent, vramBarWidth, vramColor)
 	vramLine := fmt.Sprintf("VRAM %s %s", vramBar, vramLabel)
 
-	// Power and fan line with visual indicators
+	// Temp + Power + Fan — all on one line
+	tColor := tempColor(g.TempC)
+	tempStyle := lipgloss.NewStyle().Foreground(tColor)
+	tempStr := tempStyle.Render(fmt.Sprintf("%d°C", g.TempC))
+
 	powerPercent := float64(0)
 	if g.PowerLimitW > 0 {
 		powerPercent = float64(g.PowerDrawW) / float64(g.PowerLimitW) * 100
@@ -124,20 +115,13 @@ func (g GPUPanel) Render() string {
 		powerColor = theme.Warn
 	}
 	powerStyle := lipgloss.NewStyle().Foreground(powerColor)
-	powerStr := fmt.Sprintf("⚡ %s", powerStyle.Render(fmt.Sprintf("%dW/%dW", g.PowerDrawW, g.PowerLimitW)))
+	powerStr := powerStyle.Render(fmt.Sprintf("%dW/%dW", g.PowerDrawW, g.PowerLimitW))
+	fanStr := fmt.Sprintf("Fan %d%%", g.FanPercent)
 
-	fanStr := fmt.Sprintf("💨 %d%%", g.FanPercent)
-	// Use lipgloss.Width for visual width that handles emojis and ANSI codes
-	powerPlainLen := lipgloss.Width(powerStr)
-	fanPlainLen := lipgloss.Width(fanStr)
-	powerLineSpacing := contentWidth - powerPlainLen - fanPlainLen
-	if powerLineSpacing < 1 {
-		powerLineSpacing = 1
-	}
-	powerLine := powerStr + strings.Repeat(" ", powerLineSpacing) + fanStr
+	infoLine := fmt.Sprintf("Temp %s  Pwr %s  %s", tempStr, powerStr, fanStr)
 
-	// Create panel content
-	content := utilLine + "\n" + vramLine + "\n" + powerLine
+	// Create panel content (3 lines for compact display)
+	content := utilLine + "\n" + vramLine + "\n" + infoLine
 
 	// Apply panel styling with title
 	titleWithDashes := title + " " + strings.Repeat("─", max(0, contentWidth-len(title)-1))

--- a/internal/tui/components/servicelist.go
+++ b/internal/tui/components/servicelist.go
@@ -46,16 +46,44 @@ type column struct {
 	header   string
 	minWidth int
 	flex     int // relative share of extra space (0 = fixed)
+	id       string
 }
 
-var columns = []column{
-	{header: "", minWidth: 2, flex: 0}, // health indicator
-	{header: "Service", minWidth: 12, flex: 3},
-	{header: "Model", minWidth: 10, flex: 4},
-	{header: "Device", minWidth: 8, flex: 1},
-	{header: "Port", minWidth: 5, flex: 0},
-	{header: "GPU Mem", minWidth: 7, flex: 0},
-	{header: "Uptime", minWidth: 6, flex: 0},
+// allColumns defines the superset of columns; some may be hidden dynamically.
+var allColumns = []column{
+	{id: "health", header: "", minWidth: 2, flex: 0},
+	{id: "service", header: "Service", minWidth: 12, flex: 3},
+	{id: "model", header: "Model", minWidth: 10, flex: 4},
+	{id: "device", header: "Device", minWidth: 8, flex: 1},
+	{id: "port", header: "Port", minWidth: 5, flex: 0},
+	{id: "gpumem", header: "GPU Mem", minWidth: 7, flex: 0},
+	{id: "uptime", header: "Uptime", minWidth: 6, flex: 0},
+}
+
+// activeColumns returns columns that have data, hiding empty ones.
+func (s ServiceList) activeColumns() []column {
+	hasModel := false
+	hasGPUMem := false
+	for _, svc := range s.Services {
+		if svc.Model != "" {
+			hasModel = true
+		}
+		if svc.GPUMemMB > 0 {
+			hasGPUMem = true
+		}
+	}
+
+	var cols []column
+	for _, col := range allColumns {
+		if col.id == "model" && !hasModel {
+			continue
+		}
+		if col.id == "gpumem" && !hasGPUMem {
+			continue
+		}
+		cols = append(cols, col)
+	}
+	return cols
 }
 
 // Render returns the rendered string representation of the service list.
@@ -69,11 +97,12 @@ func (s ServiceList) Render() string {
 		return theme.MutedStyle.Render(emptyMsg)
 	}
 
-	widths := s.columnWidths()
+	cols := s.activeColumns()
+	widths := s.columnWidths(cols)
 	var lines []string
 
 	// Header
-	lines = append(lines, s.renderHeader(widths))
+	lines = append(lines, s.renderHeader(widths, cols))
 
 	// Thin separator
 	sep := theme.MutedStyle.Render(strings.Repeat("─", s.Width))
@@ -82,26 +111,26 @@ func (s ServiceList) Render() string {
 	// Rows
 	for i, svc := range s.Services {
 		svc.Selected = (i == s.Cursor)
-		lines = append(lines, s.renderRow(svc, widths, i))
+		lines = append(lines, s.renderRow(svc, widths, cols, i))
 	}
 
 	return strings.Join(lines, "\n")
 }
 
-func (s ServiceList) columnWidths() []int {
-	widths := make([]int, len(columns))
+func (s ServiceList) columnWidths(cols []column) []int {
+	widths := make([]int, len(cols))
 	totalMin := 0
 	totalFlex := 0
-	for i, col := range columns {
+	for i, col := range cols {
 		widths[i] = col.minWidth
 		totalMin += col.minWidth
 		totalFlex += col.flex
 	}
-	totalMin += len(columns) - 1 // column gaps
+	totalMin += len(cols) - 1 // column gaps
 
 	extra := s.Width - totalMin
 	if extra > 0 && totalFlex > 0 {
-		for i, col := range columns {
+		for i, col := range cols {
 			if col.flex > 0 {
 				widths[i] += extra * col.flex / totalFlex
 			}
@@ -110,55 +139,54 @@ func (s ServiceList) columnWidths() []int {
 	return widths
 }
 
-func (s ServiceList) renderHeader(widths []int) string {
+func (s ServiceList) renderHeader(widths []int, cols []column) string {
 	headerStyle := lipgloss.NewStyle().
 		Foreground(theme.TextMuted).
 		Bold(true).
 		Underline(true)
 
 	var parts []string
-	for i, col := range columns {
+	for i, col := range cols {
 		parts = append(parts, pad(col.header, widths[i]))
 	}
 	return headerStyle.Render(strings.Join(parts, " "))
 }
 
-func (s ServiceList) renderRow(svc ServiceRow, widths []int, rowIdx int) string {
-	// Health indicator — use a fixed-width cell so alignment doesn't break
-	healthIcon := s.healthIndicator(svc)
-
-	// Short model: strip org prefix for display (e.g. "Qwen/Qwen3.5-35B" -> "Qwen3.5-35B")
-	model := svc.Model
-	if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
-		model = model[idx+1:]
+// cellValue returns the value for a given column id.
+func (s ServiceList) cellValue(svc ServiceRow, col column, width int) string {
+	switch col.id {
+	case "health":
+		return s.healthIndicator(svc)
+	case "service":
+		return truncate(svc.Name, width)
+	case "model":
+		model := svc.Model
+		if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
+			model = model[idx+1:]
+		}
+		return truncate(model, width)
+	case "device":
+		return truncate(svc.Device, width)
+	case "port":
+		if svc.Port > 0 {
+			return fmt.Sprintf("%d", svc.Port)
+		}
+		return ""
+	case "gpumem":
+		return formatMem(svc.GPUMemMB)
+	case "uptime":
+		return s.statusText(svc)
+	default:
+		return ""
 	}
+}
 
-	portStr := ""
-	if svc.Port > 0 {
-		portStr = fmt.Sprintf("%d", svc.Port)
-	}
-
-	gpuStr := formatMem(svc.GPUMemMB)
-
-	// Status text with color
-	statusStr := s.statusText(svc)
-
-	cells := []string{
-		healthIcon,
-		truncate(svc.Name, widths[1]),
-		truncate(model, widths[2]),
-		truncate(svc.Device, widths[3]),
-		pad(portStr, widths[4]),
-		pad(gpuStr, widths[5]),
-		pad(statusStr, widths[6]),
-	}
-
-	// Pad each cell (except health icon which is special)
+func (s ServiceList) renderRow(svc ServiceRow, widths []int, cols []column, rowIdx int) string {
 	var parts []string
-	for i, cell := range cells {
-		if i == 0 {
-			// Health icon: pad the plain-text width to the column width
-			parts = append(parts, cell+strings.Repeat(" ", max(0, widths[0]-1)))
+	for i, col := range cols {
+		cell := s.cellValue(svc, col, widths[i])
+		if col.id == "health" {
+			parts = append(parts, cell+strings.Repeat(" ", max(0, widths[i]-1)))
 		} else {
 			parts = append(parts, pad(cell, widths[i]))
 		}

--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -290,24 +290,52 @@ func (d *Dashboard) View() string {
 func (d *Dashboard) renderGridLayout() []string {
 	var sections []string
 
-	// Top row: Device cards side-by-side
+	leftWidth := (d.width - 1) / 2
+	rightWidth := d.width - leftWidth - 1
+
+	// Top row: Device card (left) + GPU panel (right), matched heights
 	if len(d.devices) > 0 {
-		deviceCards := d.renderDeviceCards()
-		sections = append(sections, deviceCards)
+		deviceCard := d.renderDeviceCardSingle(leftWidth)
+		gpuPanel := d.renderGPUInfoPanel(rightWidth)
+
+		if deviceCard != "" && gpuPanel != "" {
+			// Match heights by padding shorter side
+			leftLines := strings.Count(deviceCard, "\n") + 1
+			rightLines := strings.Count(gpuPanel, "\n") + 1
+			if leftLines < rightLines {
+				deviceCard += strings.Repeat("\n", rightLines-leftLines)
+			} else if rightLines < leftLines {
+				gpuPanel += strings.Repeat("\n", leftLines-rightLines)
+			}
+			topRow := lipgloss.JoinHorizontal(lipgloss.Top,
+				lipgloss.NewStyle().Width(leftWidth).Render(deviceCard),
+				" ",
+				lipgloss.NewStyle().Width(rightWidth).Render(gpuPanel))
+			sections = append(sections, topRow)
+		} else if deviceCard != "" {
+			sections = append(sections, deviceCard)
+		} else if gpuPanel != "" {
+			sections = append(sections, gpuPanel)
+		}
 	}
 
-	// Middle row: CPU/RAM charts (left) | GPU panels (right)
-	leftWidth := (d.width - 3) / 2
-	rightWidth := d.width - leftWidth - 3
-
+	// Middle row: CPU/RAM charts (left) | GPU util charts (right)
 	leftCol := d.renderSparklines2(leftWidth)
-	rightCol := d.renderGPUPanels2(rightWidth)
+	rightCol := d.renderGPUCharts(rightWidth)
 
 	if leftCol != "" && rightCol != "" {
-		leftStyled := lipgloss.NewStyle().Width(leftWidth).Render(leftCol)
-		rightStyled := lipgloss.NewStyle().Width(rightWidth).Render(rightCol)
-
-		middleRow := lipgloss.JoinHorizontal(lipgloss.Top, leftStyled, " ", rightStyled)
+		// Match heights
+		leftLines := strings.Count(leftCol, "\n") + 1
+		rightLines := strings.Count(rightCol, "\n") + 1
+		if leftLines < rightLines {
+			leftCol += strings.Repeat("\n", rightLines-leftLines)
+		} else if rightLines < leftLines {
+			rightCol += strings.Repeat("\n", leftLines-rightLines)
+		}
+		middleRow := lipgloss.JoinHorizontal(lipgloss.Top,
+			lipgloss.NewStyle().Width(leftWidth).Render(leftCol),
+			" ",
+			lipgloss.NewStyle().Width(rightWidth).Render(rightCol))
 		sections = append(sections, middleRow)
 	} else if leftCol != "" {
 		sections = append(sections, leftCol)
@@ -316,6 +344,101 @@ func (d *Dashboard) renderGridLayout() []string {
 	}
 
 	return sections
+}
+
+// renderDeviceCardSingle renders a single device card for the left column of grid layout.
+func (d *Dashboard) renderDeviceCardSingle(width int) string {
+	if len(d.devices) == 0 {
+		return ""
+	}
+	device := d.devices[0]
+	gpuName := d.getGPUNameForDevice(device.ID)
+	if gpuName == "" {
+		gpuName = device.GPUType
+	}
+	card := components.NewDeviceCard(
+		device.Label,
+		device.Host,
+		device.Online,
+		gpuName,
+		device.GPUCount,
+		device.CPUPercent,
+		device.RAMPercent,
+		device.ServiceCount,
+		width,
+	)
+	return card.Render()
+}
+
+// renderGPUInfoPanel renders the GPU info panel for the right column of grid layout.
+func (d *Dashboard) renderGPUInfoPanel(width int) string {
+	if len(d.metrics) == 0 {
+		return ""
+	}
+	panelWidth := width
+	if panelWidth < 40 {
+		panelWidth = 40
+	}
+	for _, metrics := range d.metrics {
+		for _, gpu := range metrics.GPUs {
+			panel := components.NewGPUPanel(
+				gpu.Index,
+				gpu.Name,
+				gpu.TempC,
+				gpu.UtilPercent,
+				gpu.VRAMUsedMB,
+				gpu.VRAMTotalMB,
+				gpu.PowerDrawW,
+				gpu.PowerLimitW,
+				gpu.FanPercent,
+				panelWidth,
+			)
+			return panel.Render()
+		}
+	}
+	return ""
+}
+
+// renderGPUCharts renders GPU utilization history charts for the right column.
+func (d *Dashboard) renderGPUCharts(availableWidth int) string {
+	if len(d.metrics) == 0 {
+		return ""
+	}
+	panelWidth := availableWidth - 2
+	if panelWidth < 40 {
+		panelWidth = 40
+	}
+	chartWidth := panelWidth - 4
+	if chartWidth < 20 {
+		chartWidth = 20
+	}
+
+	var panels []string
+	for deviceID, metrics := range d.metrics {
+		for _, gpu := range metrics.GPUs {
+			historyKey := fmt.Sprintf("%s-%d", deviceID, gpu.Index)
+			if gpuVals, ok := d.gpuHistory[historyKey]; ok && len(gpuVals) > 0 {
+				label := fmt.Sprintf(" GPU %d Util %d%%", gpu.Index, gpu.UtilPercent)
+				gpuTitle := lipgloss.NewStyle().Foreground(theme.Accent).Render(label)
+				gpuChart := components.NewStreamChart("GPU Util", gpuVals, chartWidth, 5, theme.Accent)
+				chartPanel := theme.RenderPanel(gpuTitle, gpuChart.Render(), panelWidth)
+				panels = append(panels, chartPanel)
+			}
+		}
+	}
+	if len(panels) == 0 {
+		return ""
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, panels...)
+}
+
+// getGPUNameForDevice returns the actual GPU name from metrics for a device.
+func (d *Dashboard) getGPUNameForDevice(deviceID string) string {
+	m, ok := d.metrics[deviceID]
+	if !ok || len(m.GPUs) == 0 {
+		return ""
+	}
+	return m.GPUs[0].Name
 }
 
 // renderStackedLayout renders single-column layout for narrow terminals.
@@ -380,25 +503,22 @@ func (d *Dashboard) renderDeviceCards() string {
 		return ""
 	}
 
-	cards := make([]string, len(d.devices))
-	var cardWidth int
-
-	// If width > 120, show side-by-side; otherwise stacked
-	if d.width > 120 {
-		cardWidth = (d.width - 4) / 2 // 2 cards side by side with spacing
-	} else {
-		cardWidth = d.width - 4
-	}
+	cardWidth := d.width - 4
 	if cardWidth < 20 {
 		cardWidth = 20
 	}
 
+	cards := make([]string, len(d.devices))
 	for i, device := range d.devices {
+		gpuName := d.getGPUNameForDevice(device.ID)
+		if gpuName == "" {
+			gpuName = device.GPUType
+		}
 		card := components.NewDeviceCard(
 			device.Label,
 			device.Host,
 			device.Online,
-			device.GPUType,
+			gpuName,
 			device.GPUCount,
 			device.CPUPercent,
 			device.RAMPercent,
@@ -408,21 +528,6 @@ func (d *Dashboard) renderDeviceCards() string {
 		cards[i] = card.Render()
 	}
 
-	if d.width > 120 && len(cards) >= 2 {
-		// Arrange side by side
-		var rows []string
-		for i := 0; i < len(cards); i += 2 {
-			if i+1 < len(cards) {
-				row := lipgloss.JoinHorizontal(lipgloss.Top, cards[i], "  ", cards[i+1])
-				rows = append(rows, row)
-			} else {
-				rows = append(rows, cards[i])
-			}
-		}
-		return lipgloss.JoinVertical(lipgloss.Left, rows...)
-	}
-
-	// Stack vertically
 	return lipgloss.JoinVertical(lipgloss.Left, cards...)
 }
 
@@ -472,7 +577,7 @@ func (d *Dashboard) renderGPUPanels2(availableWidth int) string {
 			if gpuVals, ok := d.gpuHistory[historyKey]; ok && len(gpuVals) > 0 {
 				label := fmt.Sprintf(" GPU %d Util %d%%", gpu.Index, gpu.UtilPercent)
 				gpuTitle := lipgloss.NewStyle().Foreground(theme.Accent).Render(label)
-				gpuChart := components.NewStreamChart("GPU Util", gpuVals, chartWidth, 6, theme.Accent)
+				gpuChart := components.NewStreamChart("GPU Util", gpuVals, chartWidth, 5, theme.Accent)
 				chartPanel := theme.RenderPanel(gpuTitle, gpuChart.Render(), panelWidth)
 				panels = append(panels, chartPanel)
 			}
@@ -502,7 +607,7 @@ func (d *Dashboard) renderSparklines2(availableWidth int) string {
 	if chartWidth < 20 {
 		chartWidth = 20
 	}
-	chartHeight := 6
+	chartHeight := 5
 
 	var charts []string
 


### PR DESCRIPTION
## Full design pass on the dashboard

### Layout (`dashboard.go`)
- **Consistent 2-column grid** with equal widths: `(width-1)/2` + 1 char gap
- **Top row**: device card (left) + GPU info panel (right), height-matched
- **Middle row**: CPU/RAM sparklines (left) + GPU util charts (right), height-matched
- Chart heights reduced from 6→5 for compactness
- Clean single-column fallback for narrow terminals (<100 chars)

### Device Card (`devicecard.go`)
- **Cleaner title**: `finn  ● online` — no more ugly `── ● online ──` dash separators
- Shows actual GPU name from metrics (e.g. `RTX Pro 6000` not just `nvidia`)
- Tighter labels: `GPU`, `Svc` instead of verbose text

### GPU Panel (`gpupanel.go`)
- Compact single-line util + VRAM bars
- Shortened VRAM labels (`24G/48G` not `24GB/48GB`)
- Temp + Power + Fan all on one line (no emojis cluttering)

### Service List (`servicelist.go`)
- **Smart columns**: auto-hides Model column when all empty, auto-hides GPU Mem when all zero
- Dynamic column system — only shows what matters
- Tighter spacing, no wasted whitespace

**267 additions, 157 deletions across 4 files**