### PR TITLE
feat: multi-device dashboard layout — per-device sections

### DIFF
--- a/internal/tui/components/devicecard.go
+++ b/internal/tui/components/devicecard.go
@@ -164,3 +164,188 @@ func (d DeviceCard) truncateAndPad(line string, width int) string {
 	}
 	return line
 }
+
+// GPUMetrics holds GPU data for inline display in a device card.
+type GPUMetrics struct {
+	Name        string
+	UtilPercent int
+	VRAMUsedMB  int64
+	VRAMTotalMB int64
+	TempC       int
+	PowerDrawW  float64
+	PowerLimitW float64
+	FanPercent  int
+}
+
+// DeviceCardFull renders a device card with GPU metrics inline.
+type DeviceCardFull struct {
+	Label        string
+	Host         string
+	Online       bool
+	CPUPercent   float64
+	RAMPercent   float64
+	ServiceCount int
+	GPUs         []GPUMetrics
+	Width        int
+}
+
+// NewDeviceCardFull creates a device card with inline GPU metrics.
+func NewDeviceCardFull(label, host string, online bool, cpuPercent, ramPercent float64, serviceCount int, gpus []GPUMetrics, width int) DeviceCardFull {
+	return DeviceCardFull{
+		Label:        label,
+		Host:         host,
+		Online:       online,
+		CPUPercent:   cpuPercent,
+		RAMPercent:   ramPercent,
+		ServiceCount: serviceCount,
+		GPUs:         gpus,
+		Width:        width,
+	}
+}
+
+// Render returns the rendered string for the full device card.
+func (d DeviceCardFull) Render() string {
+	if d.Width <= 0 {
+		return ""
+	}
+	if d.Width < 20 {
+		return strings.Repeat(" ", d.Width)
+	}
+
+	contentWidth := d.Width - 4
+	if contentWidth < 10 {
+		contentWidth = 10
+	}
+
+	// Line 1: "<label> (<host>)" right-aligned "● online"
+	statusDot := ""
+	statusText := ""
+	if d.Online {
+		statusDot = theme.StatusOnline()
+		statusText = "online"
+	} else {
+		statusDot = theme.StatusOffline()
+		statusText = "offline"
+	}
+
+	titlePart := fmt.Sprintf("%s (%s)", d.Label, d.Host)
+	statusPart := fmt.Sprintf("%s %s", statusDot, statusText)
+
+	titleLen := lipgloss.Width(titlePart)
+	statusLen := lipgloss.Width(statusPart)
+	gap := contentWidth - titleLen - statusLen
+	if gap < 1 {
+		gap = 1
+	}
+	title := titlePart + strings.Repeat(" ", gap) + statusPart
+
+	var lines []string
+
+	if len(d.GPUs) > 0 {
+		gpu := d.GPUs[0]
+		gpuName := strings.TrimPrefix(gpu.Name, "NVIDIA ")
+
+		// Line 2: "GPU: <name>   CPU [bar] X%   RAM [bar] X%"
+		gpuPrefix := fmt.Sprintf("GPU: %s", gpuName)
+		cpuSuffix := fmt.Sprintf("%.0f%%", d.CPUPercent)
+		ramSuffix := fmt.Sprintf("%.0f%%", d.RAMPercent)
+
+		// Compute bar widths from remaining space
+		fixedLen := len(gpuPrefix) + 3 + len("CPU ") + 1 + len(cpuSuffix) + 3 + len("RAM ") + 1 + len(ramSuffix)
+		barSpace := contentWidth - fixedLen
+		if barSpace < 4 {
+			barSpace = 4
+		}
+		cpuBarW := barSpace / 2
+		ramBarW := barSpace - cpuBarW
+		cpuBar := theme.ProgressBar(d.CPUPercent, cpuBarW+2)
+		ramBar := theme.ProgressBar(d.RAMPercent, ramBarW+2)
+
+		line2 := fmt.Sprintf("%s   CPU %s %s   RAM %s %s", gpuPrefix, cpuBar, cpuSuffix, ramBar, ramSuffix)
+		lines = append(lines, d.padLine(line2, contentWidth))
+
+		// Line 3: "Services: N   Util [bar] X%   VRAM [bar] X/YG"
+		svcPart := fmt.Sprintf("Services: %d", d.ServiceCount)
+		utilSuffix := fmt.Sprintf("%d%%", gpu.UtilPercent)
+		vramUsedGB := float64(gpu.VRAMUsedMB) / 1024
+		vramTotalGB := float64(gpu.VRAMTotalMB) / 1024
+		vramSuffix := fmt.Sprintf("%.0f/%.0fG", vramUsedGB, vramTotalGB)
+
+		fixedLen2 := len(svcPart) + 3 + len("Util ") + 1 + len(utilSuffix) + 3 + len("VRAM ") + 1 + len(vramSuffix)
+		barSpace2 := contentWidth - fixedLen2
+		if barSpace2 < 4 {
+			barSpace2 = 4
+		}
+		utilBarW := barSpace2 / 2
+		vramBarW := barSpace2 - utilBarW
+		utilBar := GradientProgressBar(float64(gpu.UtilPercent), utilBarW+2, theme.Accent)
+		vramPercent := float64(0)
+		if gpu.VRAMTotalMB > 0 {
+			vramPercent = float64(gpu.VRAMUsedMB) / float64(gpu.VRAMTotalMB) * 100
+		}
+		vramColor := theme.Good
+		if vramPercent > 80 {
+			vramColor = theme.Crit
+		} else if vramPercent > 50 {
+			vramColor = theme.Warn
+		}
+		vramBar := GradientProgressBar(vramPercent, vramBarW+2, vramColor)
+
+		line3 := fmt.Sprintf("%s   Util %s %s   VRAM %s %s", svcPart, utilBar, utilSuffix, vramBar, vramSuffix)
+		lines = append(lines, d.padLine(line3, contentWidth))
+
+		// Line 4: power, temp, fan
+		tColor := tempColor(gpu.TempC)
+		tempStyle := lipgloss.NewStyle().Foreground(tColor)
+		tempStr := tempStyle.Render(fmt.Sprintf("%d°C", gpu.TempC))
+
+		powerPercent := float64(0)
+		if gpu.PowerLimitW > 0 {
+			powerPercent = gpu.PowerDrawW / gpu.PowerLimitW * 100
+		}
+		powerColor := theme.Good
+		if powerPercent > 80 {
+			powerColor = theme.Crit
+		} else if powerPercent > 60 {
+			powerColor = theme.Warn
+		}
+		powerStyle := lipgloss.NewStyle().Foreground(powerColor)
+		powerStr := powerStyle.Render(fmt.Sprintf("%.0fW/%.0fW", gpu.PowerDrawW, gpu.PowerLimitW))
+
+		line4 := fmt.Sprintf("%s  %s  Fan %d%%", powerStr, tempStr, gpu.FanPercent)
+		lines = append(lines, d.padLine(line4, contentWidth))
+	} else {
+		// No GPU: simpler layout
+		// Line 2: "CPU [bar] X%   RAM [bar] X%"
+		cpuSuffix := fmt.Sprintf("%.0f%%", d.CPUPercent)
+		ramSuffix := fmt.Sprintf("%.0f%%", d.RAMPercent)
+		fixedLen := len("CPU ") + 1 + len(cpuSuffix) + 3 + len("RAM ") + 1 + len(ramSuffix)
+		barSpace := contentWidth - fixedLen
+		if barSpace < 4 {
+			barSpace = 4
+		}
+		cpuBarW := barSpace / 2
+		ramBarW := barSpace - cpuBarW
+		cpuBar := theme.ProgressBar(d.CPUPercent, cpuBarW+2)
+		ramBar := theme.ProgressBar(d.RAMPercent, ramBarW+2)
+
+		line2 := fmt.Sprintf("CPU %s %s   RAM %s %s", cpuBar, cpuSuffix, ramBar, ramSuffix)
+		lines = append(lines, d.padLine(line2, contentWidth))
+
+		// Line 3: "Services: N"
+		line3 := fmt.Sprintf("Services: %d", d.ServiceCount)
+		lines = append(lines, d.padLine(line3, contentWidth))
+	}
+
+	content := strings.Join(lines, "\n")
+	panel := theme.Panel(title).Width(d.Width).Render(content)
+	return panel
+}
+
+func (d DeviceCardFull) padLine(line string, width int) string {
+	visualWidth := lipgloss.Width(line)
+	if visualWidth < width {
+		line = line + strings.Repeat(" ", width-visualWidth)
+	}
+	return line
+}

--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -286,178 +286,135 @@ func (d *Dashboard) View() string {
 	return lipgloss.NewStyle().Width(d.width).Render(content)
 }
 
-// renderGridLayout renders btop-inspired side-by-side panels.
+// renderGridLayout renders per-device sections: card + side-by-side sparklines.
 func (d *Dashboard) renderGridLayout() []string {
 	var sections []string
 
-	leftWidth := (d.width - 1) / 2
-	rightWidth := d.width - leftWidth - 1
+	for _, device := range d.devices {
+		// Render device card (full width) with GPU info inline
+		card := d.renderDeviceCardWithGPU(device, d.width)
+		sections = append(sections, card)
 
-	// Top row: Device card (left) + GPU panel (right), matched heights
-	if len(d.devices) > 0 {
-		deviceCard := d.renderDeviceCardSingle(leftWidth)
-		gpuPanel := d.renderGPUInfoPanel(rightWidth)
-
-		if deviceCard != "" && gpuPanel != "" {
-			// Match heights by padding shorter side
-			leftLines := strings.Count(deviceCard, "\n") + 1
-			rightLines := strings.Count(gpuPanel, "\n") + 1
-			if leftLines < rightLines {
-				deviceCard += strings.Repeat("\n", rightLines-leftLines)
-			} else if rightLines < leftLines {
-				gpuPanel += strings.Repeat("\n", leftLines-rightLines)
-			}
-			topRow := lipgloss.JoinHorizontal(lipgloss.Top,
-				lipgloss.NewStyle().Width(leftWidth).Render(deviceCard),
-				" ",
-				lipgloss.NewStyle().Width(rightWidth).Render(gpuPanel))
-			sections = append(sections, topRow)
-		} else if deviceCard != "" {
-			sections = append(sections, deviceCard)
-		} else if gpuPanel != "" {
-			sections = append(sections, gpuPanel)
+		// Render sparklines for this device horizontally (CPU | RAM | GPU side by side)
+		sparklines := d.renderDeviceSparklines(device.ID, d.width)
+		if sparklines != "" {
+			sections = append(sections, sparklines)
 		}
-	}
-
-	// Middle row: CPU/RAM charts (left) | GPU util charts (right)
-	leftCol := d.renderSparklines2(leftWidth)
-	rightCol := d.renderGPUCharts(rightWidth)
-
-	if leftCol != "" && rightCol != "" {
-		// Match heights
-		leftLines := strings.Count(leftCol, "\n") + 1
-		rightLines := strings.Count(rightCol, "\n") + 1
-		if leftLines < rightLines {
-			leftCol += strings.Repeat("\n", rightLines-leftLines)
-		} else if rightLines < leftLines {
-			rightCol += strings.Repeat("\n", leftLines-rightLines)
-		}
-		middleRow := lipgloss.JoinHorizontal(lipgloss.Top,
-			lipgloss.NewStyle().Width(leftWidth).Render(leftCol),
-			" ",
-			lipgloss.NewStyle().Width(rightWidth).Render(rightCol))
-		sections = append(sections, middleRow)
-	} else if leftCol != "" {
-		sections = append(sections, leftCol)
-	} else if rightCol != "" {
-		sections = append(sections, rightCol)
 	}
 
 	return sections
 }
 
-// renderDeviceCardSingle renders a single device card for the left column of grid layout.
-func (d *Dashboard) renderDeviceCardSingle(width int) string {
-	if len(d.devices) == 0 {
-		return ""
+// renderDeviceCardWithGPU renders a full-width device card with GPU metrics inline.
+func (d *Dashboard) renderDeviceCardWithGPU(device DashboardDevice, width int) string {
+	var gpus []components.GPUMetrics
+	if m, ok := d.metrics[device.ID]; ok {
+		for _, gpu := range m.GPUs {
+			gpus = append(gpus, components.GPUMetrics{
+				Name:        gpu.Name,
+				UtilPercent: gpu.UtilPercent,
+				VRAMUsedMB:  gpu.VRAMUsedMB,
+				VRAMTotalMB: gpu.VRAMTotalMB,
+				TempC:       gpu.TempC,
+				PowerDrawW:  float64(gpu.PowerDrawW),
+				PowerLimitW: float64(gpu.PowerLimitW),
+				FanPercent:  gpu.FanPercent,
+			})
+		}
 	}
-	device := d.devices[0]
-	gpuName := d.getGPUNameForDevice(device.ID)
-	if gpuName == "" {
-		gpuName = device.GPUType
-	}
-	card := components.NewDeviceCard(
+
+	card := components.NewDeviceCardFull(
 		device.Label,
 		device.Host,
 		device.Online,
-		gpuName,
-		device.GPUCount,
 		device.CPUPercent,
 		device.RAMPercent,
 		device.ServiceCount,
+		gpus,
 		width,
 	)
 	return card.Render()
 }
 
-// renderGPUInfoPanel renders the GPU info panel for the right column of grid layout.
-func (d *Dashboard) renderGPUInfoPanel(width int) string {
-	if len(d.metrics) == 0 {
+// renderDeviceSparklines renders CPU + RAM + optionally GPU sparklines side by side for one device.
+func (d *Dashboard) renderDeviceSparklines(deviceID string, availableWidth int) string {
+	cpuVals := d.cpuHistory[deviceID]
+	ramVals := d.ramHistory[deviceID]
+	if len(cpuVals) == 0 && len(ramVals) == 0 {
 		return ""
 	}
-	panelWidth := width
-	if panelWidth < 40 {
-		panelWidth = 40
-	}
-	for _, metrics := range d.metrics {
-		for _, gpu := range metrics.GPUs {
-			panel := components.NewGPUPanel(
-				gpu.Index,
-				gpu.Name,
-				gpu.TempC,
-				gpu.UtilPercent,
-				gpu.VRAMUsedMB,
-				gpu.VRAMTotalMB,
-				gpu.PowerDrawW,
-				gpu.PowerLimitW,
-				gpu.FanPercent,
-				panelWidth,
-			)
-			return panel.Render()
-		}
-	}
-	return ""
-}
 
-// renderGPUCharts renders GPU utilization history charts for the right column.
-func (d *Dashboard) renderGPUCharts(availableWidth int) string {
-	if len(d.metrics) == 0 {
-		return ""
-	}
-	panelWidth := availableWidth - 2
-	if panelWidth < 40 {
-		panelWidth = 40
-	}
-	chartWidth := panelWidth - 4
-	if chartWidth < 20 {
-		chartWidth = 20
-	}
-
-	var panels []string
-	for deviceID, metrics := range d.metrics {
-		for _, gpu := range metrics.GPUs {
+	// Determine if this device has GPU history
+	var gpuVals []float64
+	var gpuLabel string
+	if m, ok := d.metrics[deviceID]; ok {
+		for _, gpu := range m.GPUs {
 			historyKey := fmt.Sprintf("%s-%d", deviceID, gpu.Index)
-			if gpuVals, ok := d.gpuHistory[historyKey]; ok && len(gpuVals) > 0 {
-				label := fmt.Sprintf(" GPU %d Util %d%%", gpu.Index, gpu.UtilPercent)
-				gpuTitle := lipgloss.NewStyle().Foreground(theme.Accent).Render(label)
-				gpuChart := components.NewStreamChart("GPU Util", gpuVals, chartWidth, 5, theme.Accent)
-				chartPanel := theme.RenderPanel(gpuTitle, gpuChart.Render(), panelWidth)
-				panels = append(panels, chartPanel)
+			if vals, ok := d.gpuHistory[historyKey]; ok && len(vals) > 0 {
+				gpuVals = vals
+				gpuLabel = fmt.Sprintf("GPU %d%%", gpu.UtilPercent)
+				break
 			}
 		}
 	}
-	if len(panels) == 0 {
-		return ""
-	}
-	return lipgloss.JoinVertical(lipgloss.Left, panels...)
-}
 
-// getGPUNameForDevice returns the actual GPU name from metrics for a device.
-func (d *Dashboard) getGPUNameForDevice(deviceID string) string {
-	m, ok := d.metrics[deviceID]
-	if !ok || len(m.GPUs) == 0 {
+	numCharts := 2
+	if len(gpuVals) > 0 {
+		numCharts = 3
+	}
+
+	chartWidth := (availableWidth - numCharts + 1) / numCharts
+	if chartWidth < 20 {
+		chartWidth = 20
+	}
+	chartHeight := 5
+	innerWidth := chartWidth - 4
+	if innerWidth < 10 {
+		innerWidth = 10
+	}
+
+	var charts []string
+
+	if len(cpuVals) > 0 {
+		label := fmt.Sprintf(" CPU %.0f%%", cpuVals[len(cpuVals)-1])
+		cpuTitle := theme.GoodStyle.Render(label)
+		cpu := components.NewStreamChart("CPU", cpuVals, innerWidth, chartHeight, theme.Good)
+		charts = append(charts, theme.RenderPanel(cpuTitle, cpu.Render(), chartWidth))
+	}
+
+	if len(ramVals) > 0 {
+		label := fmt.Sprintf(" RAM %.0f%%", ramVals[len(ramVals)-1])
+		ramTitle := theme.WarnStyle.Render(label)
+		ram := components.NewStreamChart("RAM", ramVals, innerWidth, chartHeight, theme.Accent)
+		charts = append(charts, theme.RenderPanel(ramTitle, ram.Render(), chartWidth))
+	}
+
+	if len(gpuVals) > 0 {
+		gpuTitle := lipgloss.NewStyle().Foreground(theme.Accent).Render(" " + gpuLabel)
+		gpuChart := components.NewStreamChart("GPU", gpuVals, innerWidth, chartHeight, theme.Accent)
+		charts = append(charts, theme.RenderPanel(gpuTitle, gpuChart.Render(), chartWidth))
+	}
+
+	if len(charts) == 0 {
 		return ""
 	}
-	return m.GPUs[0].Name
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, charts...)
 }
 
 // renderStackedLayout renders single-column layout for narrow terminals.
 func (d *Dashboard) renderStackedLayout() []string {
 	var sections []string
 
-	if len(d.devices) > 0 {
-		deviceCards := d.renderDeviceCards()
-		sections = append(sections, deviceCards)
-	}
+	for _, device := range d.devices {
+		card := d.renderDeviceCardWithGPU(device, d.width)
+		sections = append(sections, card)
 
-	gpuPanels := d.renderGPUPanels()
-	if gpuPanels != "" {
-		sections = append(sections, gpuPanels)
-	}
-
-	sparklines := d.renderSparklines()
-	if sparklines != "" {
-		sections = append(sections, sparklines)
+		// Stacked sparklines (vertical) for narrow layout
+		sparklines := d.renderDeviceSparklines(device.ID, d.width)
+		if sparklines != "" {
+			sections = append(sections, sparklines)
+		}
 	}
 
 	return sections
@@ -498,150 +455,6 @@ func (d *Dashboard) renderHeader() string {
 		Render(headerText)
 }
 
-func (d *Dashboard) renderDeviceCards() string {
-	if len(d.devices) == 0 {
-		return ""
-	}
-
-	cardWidth := d.width - 4
-	if cardWidth < 20 {
-		cardWidth = 20
-	}
-
-	cards := make([]string, len(d.devices))
-	for i, device := range d.devices {
-		gpuName := d.getGPUNameForDevice(device.ID)
-		if gpuName == "" {
-			gpuName = device.GPUType
-		}
-		card := components.NewDeviceCard(
-			device.Label,
-			device.Host,
-			device.Online,
-			gpuName,
-			device.GPUCount,
-			device.CPUPercent,
-			device.RAMPercent,
-			device.ServiceCount,
-			cardWidth,
-		)
-		cards[i] = card.Render()
-	}
-
-	return lipgloss.JoinVertical(lipgloss.Left, cards...)
-}
-
-func (d *Dashboard) renderGPUPanels() string {
-	return d.renderGPUPanels2(d.width)
-}
-
-func (d *Dashboard) renderGPUPanels2(availableWidth int) string {
-	if len(d.metrics) == 0 {
-		return ""
-	}
-
-	var panels []string
-	panelWidth := availableWidth - 2
-	if panelWidth < 40 {
-		panelWidth = 40
-	}
-
-	chartWidth := panelWidth - 4
-	if chartWidth < 20 {
-		chartWidth = 20
-	}
-
-	for deviceID, metrics := range d.metrics {
-		device := d.findDevice(deviceID)
-		if device == nil {
-			continue
-		}
-
-		for _, gpu := range metrics.GPUs {
-			panel := components.NewGPUPanel(
-				gpu.Index,
-				gpu.Name,
-				gpu.TempC,
-				gpu.UtilPercent,
-				gpu.VRAMUsedMB,
-				gpu.VRAMTotalMB,
-				gpu.PowerDrawW,
-				gpu.PowerLimitW,
-				gpu.FanPercent,
-				panelWidth,
-			)
-			panels = append(panels, panel.Render())
-
-			// GPU utilization history chart
-			historyKey := fmt.Sprintf("%s-%d", deviceID, gpu.Index)
-			if gpuVals, ok := d.gpuHistory[historyKey]; ok && len(gpuVals) > 0 {
-				label := fmt.Sprintf(" GPU %d Util %d%%", gpu.Index, gpu.UtilPercent)
-				gpuTitle := lipgloss.NewStyle().Foreground(theme.Accent).Render(label)
-				gpuChart := components.NewStreamChart("GPU Util", gpuVals, chartWidth, 5, theme.Accent)
-				chartPanel := theme.RenderPanel(gpuTitle, gpuChart.Render(), panelWidth)
-				panels = append(panels, chartPanel)
-			}
-		}
-	}
-
-	if len(panels) == 0 {
-		return ""
-	}
-
-	return lipgloss.JoinVertical(lipgloss.Left, panels...)
-}
-
-func (d *Dashboard) renderSparklines() string {
-	return d.renderSparklines2(d.width)
-}
-
-func (d *Dashboard) renderSparklines2(availableWidth int) string {
-	if len(d.cpuHistory) == 0 && len(d.ramHistory) == 0 {
-		return ""
-	}
-
-	// Panel border + padding takes 4 chars (2 border + 2 padding),
-	// then the chart Y-axis labels take ~6 chars
-	panelWidth := availableWidth - 2
-	chartWidth := panelWidth - 4 // inner content after border+padding
-	if chartWidth < 20 {
-		chartWidth = 20
-	}
-	chartHeight := 5
-
-	var charts []string
-
-	for deviceID := range d.cpuHistory {
-		device := d.findDevice(deviceID)
-		if device == nil {
-			continue
-		}
-
-		// CPU streamline chart
-		if cpuVals, ok := d.cpuHistory[deviceID]; ok && len(cpuVals) > 0 {
-			label := fmt.Sprintf(" %s CPU %.0f%%", device.Label, cpuVals[len(cpuVals)-1])
-			cpuTitle := theme.GoodStyle.Render(label)
-			cpu := components.NewStreamChart("CPU", cpuVals, chartWidth, chartHeight, theme.Good)
-			cpuPanel := theme.RenderPanel(cpuTitle, cpu.Render(), panelWidth)
-			charts = append(charts, cpuPanel)
-		}
-
-		// RAM streamline chart
-		if ramVals, ok := d.ramHistory[deviceID]; ok && len(ramVals) > 0 {
-			label := fmt.Sprintf(" %s RAM %.0f%%", device.Label, ramVals[len(ramVals)-1])
-			ramTitle := theme.WarnStyle.Render(label)
-			ram := components.NewStreamChart("RAM", ramVals, chartWidth, chartHeight, theme.Accent)
-			ramPanel := theme.RenderPanel(ramTitle, ram.Render(), panelWidth)
-			charts = append(charts, ramPanel)
-		}
-	}
-
-	if len(charts) == 0 {
-		return ""
-	}
-
-	return lipgloss.JoinVertical(lipgloss.Left, charts...)
-}
 
 func (d *Dashboard) renderServiceList() string {
 	serviceRows := d.buildServiceRows()


### PR DESCRIPTION
## Problem
Dashboard only showed first device in grid layout. With 2+ devices (e.g. finn + darkporgs), second device was barely visible — no name, no sparklines, confusing layout.

## Solution: Per-device sections
Each device gets its own section with:

**Full-width device card with inline GPU:**
```
finn (100.64.0.1)                                    ● online
GPU: RTX Pro 6000     CPU [████░░░░] 1%   RAM [██░░░░] 9%
Services: 5           Util [░░░░░░░░] 0%  VRAM 1/96G
                      5W/600W  30°C  Fan 30%

darkporgs (100.88.219.18)                            ● online
GPU: None             CPU [░░░░░░░░] 0%   RAM [░░░░░░] 0%
Services: 0
```

**Horizontal sparklines per device:** CPU | RAM | GPU side-by-side (2 charts for no-GPU devices, 3 for GPU devices)

## Changes
- **`dashboard.go`**: Rewrote `renderGridLayout()` + `renderStackedLayout()` to loop all devices. Added `renderDeviceCardWithGPU()` + `renderDeviceSparklines()`. Removed 9 dead functions.
- **`devicecard.go`**: New `DeviceCardFull` with `GPUMetrics` — inline GPU util/VRAM/power/temp/fan bars in the device card.