### PR TITLE
feat: device labels + vLLM tok/s and prefill metrics

### DIFF
--- a/internal/agent/docker.go
+++ b/internal/agent/docker.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -10,19 +11,27 @@ import (
 	"path"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
 
+// VLLMMetrics holds vLLM inference throughput metrics.
+type VLLMMetrics struct {
+	GenerationTokPerSec float64 `json:"generation_tok_per_s"`
+	PromptTokPerSec     float64 `json:"prompt_tok_per_s"`
+}
+
 // Container represents a running container.
 type Container struct {
-	ID      string            `json:"id"`
-	Name    string            `json:"name"`
-	Image   string            `json:"image"`
-	Status  string            `json:"status"`
-	Ports   map[string]string `json:"ports"`
-	Created time.Time         `json:"created"`
-	Uptime  int64             `json:"uptime_seconds"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Image       string            `json:"image"`
+	Status      string            `json:"status"`
+	Ports       map[string]string `json:"ports"`
+	Created     time.Time         `json:"created"`
+	Uptime      int64             `json:"uptime_seconds"`
+	VLLMMetrics *VLLMMetrics      `json:"vllm_metrics,omitempty"`
 }
 
 // ContainerRequest represents a container deployment request.
@@ -106,6 +115,18 @@ func listContainers() ([]Container, error) {
 			Ports:   ports,
 			Created: created,
 			Uptime:  uptime,
+		}
+
+		// Scrape vLLM metrics for vLLM containers
+		if isVLLMImage(container.Image) && container.Status == "running" {
+			for _, ext := range container.Ports {
+				if ext != "" {
+					if vm, err := scrapeVLLMMetrics(ext); err == nil {
+						container.VLLMMetrics = vm
+					}
+					break
+				}
+			}
 		}
 
 		containers = append(containers, container)
@@ -487,6 +508,47 @@ func probeContainerHealth(ports map[string]string, image string) string {
 	}
 	_ = conn.Close()
 	return "healthy"
+}
+
+// scrapeVLLMMetrics fetches Prometheus metrics from a vLLM container's /metrics
+// endpoint and parses generation and prompt throughput.
+func scrapeVLLMMetrics(port string) (*VLLMMetrics, error) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://127.0.0.1:" + port + "/metrics")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("vllm metrics returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return nil, err
+	}
+
+	m := &VLLMMetrics{}
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "vllm:avg_generation_throughput_toks_per_s") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				m.GenerationTokPerSec, _ = strconv.ParseFloat(parts[len(parts)-1], 64)
+			}
+		} else if strings.HasPrefix(line, "vllm:avg_prompt_throughput_toks_per_s") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				m.PromptTokPerSec, _ = strconv.ParseFloat(parts[len(parts)-1], 64)
+			}
+		}
+	}
+	return m, nil
 }
 
 // normalizeServicePorts remaps user-specified ports so the container-internal

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -62,16 +62,18 @@ type GPUMetrics struct {
 
 // ContainerMetrics holds per-container resource usage.
 type ContainerMetrics struct {
-	ID          string            `json:"id"`
-	Name        string            `json:"name"`
-	Image       string            `json:"image,omitempty"`
-	Status      string            `json:"status"`
-	CPUPercent  float64           `json:"cpu_percent"`
-	MemUsedMB   int64             `json:"memory_used_mb"`
-	GPUMemoryMB int64             `json:"gpu_memory_mb,omitempty"`
-	Uptime      int64             `json:"uptime_seconds"`
-	Ports       map[string]string `json:"ports,omitempty"`
-	Health      string            `json:"health,omitempty"` // "healthy", "unhealthy", "starting", ""
+	ID                  string            `json:"id"`
+	Name                string            `json:"name"`
+	Image               string            `json:"image,omitempty"`
+	Status              string            `json:"status"`
+	CPUPercent          float64           `json:"cpu_percent"`
+	MemUsedMB           int64             `json:"memory_used_mb"`
+	GPUMemoryMB         int64             `json:"gpu_memory_mb,omitempty"`
+	Uptime              int64             `json:"uptime_seconds"`
+	Ports               map[string]string `json:"ports,omitempty"`
+	Health              string            `json:"health,omitempty"` // "healthy", "unhealthy", "starting", ""
+	GenerationTokPerSec float64           `json:"generation_tok_per_s,omitempty"`
+	PromptTokPerSec     float64           `json:"prompt_tok_per_s,omitempty"`
 }
 
 // CollectMetrics gathers all system metrics.

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -205,17 +205,26 @@ func mergeContainerMetrics(metricContainers []ContainerMetrics, dockerContainers
 			metricContainers[idx].Image = container.Image
 			metricContainers[idx].Uptime = container.Uptime
 			metricContainers[idx].Ports = container.Ports
+			if container.VLLMMetrics != nil {
+				metricContainers[idx].GenerationTokPerSec = container.VLLMMetrics.GenerationTokPerSec
+				metricContainers[idx].PromptTokPerSec = container.VLLMMetrics.PromptTokPerSec
+			}
 			continue
 		}
 
-		metricContainers = append(metricContainers, ContainerMetrics{
+		cm := ContainerMetrics{
 			ID:     id,
 			Name:   container.Name,
 			Image:  container.Image,
 			Status: container.Status,
 			Uptime: container.Uptime,
 			Ports:  container.Ports,
-		})
+		}
+		if container.VLLMMetrics != nil {
+			cm.GenerationTokPerSec = container.VLLMMetrics.GenerationTokPerSec
+			cm.PromptTokPerSec = container.VLLMMetrics.PromptTokPerSec
+		}
+		metricContainers = append(metricContainers, cm)
 
 		if id != "" {
 			idIndex[id] = len(metricContainers) - 1

--- a/internal/tui/components/devicecard.go
+++ b/internal/tui/components/devicecard.go
@@ -141,15 +141,16 @@ func (d DeviceCard) Render() string {
 	}
 
 	// Truncate and pad lines to content width
+	title = d.truncateAndPad(title, contentWidth)
 	gpuLine = d.truncateAndPad(gpuLine, contentWidth)
 	metricsLine = d.truncateAndPad(metricsLine, contentWidth)
 	servicesLine = d.truncateAndPad(servicesLine, contentWidth)
 
-	// Create panel content
-	content := gpuLine + "\n" + metricsLine + "\n" + servicesLine
+	// Create panel content with title as first line
+	content := title + "\n" + gpuLine + "\n" + metricsLine + "\n" + servicesLine
 
-	// Apply panel styling with title
-	panel := theme.Panel(title).Width(d.Width).Render(content)
+	// Apply panel styling
+	panel := theme.Panel("").Width(d.Width).Render(content)
 
 	return panel
 }
@@ -241,28 +242,42 @@ func (d DeviceCardFull) Render() string {
 
 	var lines []string
 
+	// Title is the first content line
+	lines = append(lines, d.padLine(title, contentWidth))
+
 	if len(d.GPUs) > 0 {
 		gpu := d.GPUs[0]
 		gpuName := strings.TrimPrefix(gpu.Name, "NVIDIA ")
 
-		// Line 2: "GPU: <name>   CPU [bar] X%   RAM [bar] X%"
-		gpuPrefix := fmt.Sprintf("GPU: %s", gpuName)
+		// GPU line
+		gpuLine := fmt.Sprintf("GPU: %s", gpuName)
+		lines = append(lines, d.padLine(gpuLine, contentWidth))
+
+		// CPU and RAM bars — try side-by-side, fall back to stacked
 		cpuSuffix := fmt.Sprintf("%.0f%%", d.CPUPercent)
 		ramSuffix := fmt.Sprintf("%.0f%%", d.RAMPercent)
 
-		// Compute bar widths from remaining space
-		fixedLen := len(gpuPrefix) + 3 + len("CPU ") + 1 + len(cpuSuffix) + 3 + len("RAM ") + 1 + len(ramSuffix)
+		// Side-by-side: "CPU [bar] X%   RAM [bar] X%"
+		fixedLen := len("CPU ") + 1 + len(cpuSuffix) + 3 + len("RAM ") + 1 + len(ramSuffix) + 4
 		barSpace := contentWidth - fixedLen
-		if barSpace < 4 {
-			barSpace = 4
+		if barSpace >= 8 {
+			cpuBarW := barSpace / 2
+			ramBarW := barSpace - cpuBarW
+			cpuBar := theme.ProgressBar(d.CPUPercent, cpuBarW+2)
+			ramBar := theme.ProgressBar(d.RAMPercent, ramBarW+2)
+			metricsLine := fmt.Sprintf("CPU %s %s   RAM %s %s", cpuBar, cpuSuffix, ramBar, ramSuffix)
+			lines = append(lines, d.padLine(metricsLine, contentWidth))
+		} else {
+			// Stacked: one bar per line
+			singleBarW := contentWidth - len("CPU ") - 1 - len(cpuSuffix) - 2
+			if singleBarW < 4 {
+				singleBarW = 4
+			}
+			cpuBar := theme.ProgressBar(d.CPUPercent, singleBarW+2)
+			ramBar := theme.ProgressBar(d.RAMPercent, singleBarW+2)
+			lines = append(lines, d.padLine(fmt.Sprintf("CPU %s %s", cpuBar, cpuSuffix), contentWidth))
+			lines = append(lines, d.padLine(fmt.Sprintf("RAM %s %s", ramBar, ramSuffix), contentWidth))
 		}
-		cpuBarW := barSpace / 2
-		ramBarW := barSpace - cpuBarW
-		cpuBar := theme.ProgressBar(d.CPUPercent, cpuBarW+2)
-		ramBar := theme.ProgressBar(d.RAMPercent, ramBarW+2)
-
-		line2 := fmt.Sprintf("%s   CPU %s %s   RAM %s %s", gpuPrefix, cpuBar, cpuSuffix, ramBar, ramSuffix)
-		lines = append(lines, d.padLine(line2, contentWidth))
 
 		// Line 3: "Services: N   Util [bar] X%   VRAM [bar] X/YG"
 		svcPart := fmt.Sprintf("Services: %d", d.ServiceCount)
@@ -316,21 +331,28 @@ func (d DeviceCardFull) Render() string {
 		lines = append(lines, d.padLine(line4, contentWidth))
 	} else {
 		// No GPU: simpler layout
-		// Line 2: "CPU [bar] X%   RAM [bar] X%"
 		cpuSuffix := fmt.Sprintf("%.0f%%", d.CPUPercent)
 		ramSuffix := fmt.Sprintf("%.0f%%", d.RAMPercent)
-		fixedLen := len("CPU ") + 1 + len(cpuSuffix) + 3 + len("RAM ") + 1 + len(ramSuffix)
-		barSpace := contentWidth - fixedLen
-		if barSpace < 4 {
-			barSpace = 4
-		}
-		cpuBarW := barSpace / 2
-		ramBarW := barSpace - cpuBarW
-		cpuBar := theme.ProgressBar(d.CPUPercent, cpuBarW+2)
-		ramBar := theme.ProgressBar(d.RAMPercent, ramBarW+2)
 
-		line2 := fmt.Sprintf("CPU %s %s   RAM %s %s", cpuBar, cpuSuffix, ramBar, ramSuffix)
-		lines = append(lines, d.padLine(line2, contentWidth))
+		fixedLen := len("CPU ") + 1 + len(cpuSuffix) + 3 + len("RAM ") + 1 + len(ramSuffix) + 4
+		barSpace := contentWidth - fixedLen
+		if barSpace >= 8 {
+			cpuBarW := barSpace / 2
+			ramBarW := barSpace - cpuBarW
+			cpuBar := theme.ProgressBar(d.CPUPercent, cpuBarW+2)
+			ramBar := theme.ProgressBar(d.RAMPercent, ramBarW+2)
+			line2 := fmt.Sprintf("CPU %s %s   RAM %s %s", cpuBar, cpuSuffix, ramBar, ramSuffix)
+			lines = append(lines, d.padLine(line2, contentWidth))
+		} else {
+			singleBarW := contentWidth - len("CPU ") - 1 - len(cpuSuffix) - 2
+			if singleBarW < 4 {
+				singleBarW = 4
+			}
+			cpuBar := theme.ProgressBar(d.CPUPercent, singleBarW+2)
+			ramBar := theme.ProgressBar(d.RAMPercent, singleBarW+2)
+			lines = append(lines, d.padLine(fmt.Sprintf("CPU %s %s", cpuBar, cpuSuffix), contentWidth))
+			lines = append(lines, d.padLine(fmt.Sprintf("RAM %s %s", ramBar, ramSuffix), contentWidth))
+		}
 
 		// Line 3: "Services: N"
 		line3 := fmt.Sprintf("Services: %d", d.ServiceCount)
@@ -338,7 +360,7 @@ func (d DeviceCardFull) Render() string {
 	}
 
 	content := strings.Join(lines, "\n")
-	panel := theme.Panel(title).Width(d.Width).Render(content)
+	panel := theme.Panel("").Width(d.Width).Render(content)
 	return panel
 }
 

--- a/internal/tui/components/servicelist.go
+++ b/internal/tui/components/servicelist.go
@@ -11,18 +11,20 @@ import (
 
 // ServiceRow represents a single service in the list.
 type ServiceRow struct {
-	Name       string
-	Type       string // vllm, llamacpp, comfyui
-	Model      string
-	Status     string // running, stopped, error
-	Health     string // healthy, unhealthy, starting, ""
-	Device     string // device label
-	Port       int
-	CPUPercent float64
-	MemUsedMB  int64
-	GPUMemMB   int64
-	Uptime     string
-	Selected   bool
+	Name                string
+	Type                string // vllm, llamacpp, comfyui
+	Model               string
+	Status              string // running, stopped, error
+	Health              string // healthy, unhealthy, starting, ""
+	Device              string // device label
+	Port                int
+	CPUPercent          float64
+	MemUsedMB           int64
+	GPUMemMB            int64
+	Uptime              string
+	Selected            bool
+	GenerationTokPerSec float64
+	PromptTokPerSec     float64
 }
 
 // ServiceList renders a table of services.
@@ -57,6 +59,8 @@ var allColumns = []column{
 	{id: "device", header: "Device", minWidth: 8, flex: 1},
 	{id: "port", header: "Port", minWidth: 5, flex: 0},
 	{id: "gpumem", header: "GPU Mem", minWidth: 7, flex: 0},
+	{id: "toks", header: "Tok/s", minWidth: 6, flex: 0},
+	{id: "prefill", header: "Prefill", minWidth: 7, flex: 0},
 	{id: "uptime", header: "Uptime", minWidth: 6, flex: 0},
 }
 
@@ -64,12 +68,20 @@ var allColumns = []column{
 func (s ServiceList) activeColumns() []column {
 	hasModel := false
 	hasGPUMem := false
+	hasToks := false
+	hasPrefill := false
 	for _, svc := range s.Services {
 		if svc.Model != "" {
 			hasModel = true
 		}
 		if svc.GPUMemMB > 0 {
 			hasGPUMem = true
+		}
+		if svc.GenerationTokPerSec > 0 {
+			hasToks = true
+		}
+		if svc.PromptTokPerSec > 0 {
+			hasPrefill = true
 		}
 	}
 
@@ -79,6 +91,12 @@ func (s ServiceList) activeColumns() []column {
 			continue
 		}
 		if col.id == "gpumem" && !hasGPUMem {
+			continue
+		}
+		if col.id == "toks" && !hasToks {
+			continue
+		}
+		if col.id == "prefill" && !hasPrefill {
 			continue
 		}
 		cols = append(cols, col)
@@ -174,6 +192,16 @@ func (s ServiceList) cellValue(svc ServiceRow, col column, width int) string {
 		return ""
 	case "gpumem":
 		return formatMem(svc.GPUMemMB)
+	case "toks":
+		if svc.GenerationTokPerSec > 0 {
+			return fmt.Sprintf("%.1f", svc.GenerationTokPerSec)
+		}
+		return "-"
+	case "prefill":
+		if svc.PromptTokPerSec > 0 {
+			return fmt.Sprintf("%.1f", svc.PromptTokPerSec)
+		}
+		return "-"
 	case "uptime":
 		return s.statusText(svc)
 	default:

--- a/internal/tui/views/dashboard.go
+++ b/internal/tui/views/dashboard.go
@@ -93,16 +93,18 @@ type GPUData struct {
 }
 
 type ContainerData struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	Image         string            `json:"image"`
-	Status        string            `json:"status"`
-	CPUPercent    float64           `json:"cpu_percent"`
-	MemUsedMB     int64             `json:"memory_used_mb"`
-	GPUMemMB      int64             `json:"gpu_memory_mb"`
-	UptimeSeconds int64             `json:"uptime_seconds"`
-	Ports         map[string]string `json:"ports"`
-	Health        string            `json:"health"`
+	ID                  string            `json:"id"`
+	Name                string            `json:"name"`
+	Image               string            `json:"image"`
+	Status              string            `json:"status"`
+	CPUPercent          float64           `json:"cpu_percent"`
+	MemUsedMB           int64             `json:"memory_used_mb"`
+	GPUMemMB            int64             `json:"gpu_memory_mb"`
+	UptimeSeconds       int64             `json:"uptime_seconds"`
+	Ports               map[string]string `json:"ports"`
+	Health              string            `json:"health"`
+	GenerationTokPerSec float64           `json:"generation_tok_per_s"`
+	PromptTokPerSec     float64           `json:"prompt_tok_per_s"`
 }
 
 type DashboardDevice struct {
@@ -490,17 +492,19 @@ func (d *Dashboard) buildServiceRows() []components.ServiceRow {
 			displayName := strings.TrimPrefix(container.Name, "yokai-")
 
 			row := components.ServiceRow{
-				Name:       displayName,
-				Type:       serviceType,
-				Model:      d.getServiceModel(container),
-				Status:     container.Status,
-				Health:     container.Health,
-				Device:     deviceLabel,
-				Port:       extractExternalPort(container.Ports),
-				CPUPercent: container.CPUPercent,
-				MemUsedMB:  container.MemUsedMB,
-				GPUMemMB:   container.GPUMemMB,
-				Uptime:     formatUptime(container.UptimeSeconds),
+				Name:                displayName,
+				Type:                serviceType,
+				Model:               d.getServiceModel(container),
+				Status:              container.Status,
+				Health:              container.Health,
+				Device:              deviceLabel,
+				Port:                extractExternalPort(container.Ports),
+				CPUPercent:          container.CPUPercent,
+				MemUsedMB:           container.MemUsedMB,
+				GPUMemMB:            container.GPUMemMB,
+				Uptime:              formatUptime(container.UptimeSeconds),
+				GenerationTokPerSec: container.GenerationTokPerSec,
+				PromptTokPerSec:     container.PromptTokPerSec,
 			}
 			rows = append(rows, row)
 		}


### PR DESCRIPTION
## Fixes

### 1. Device card labels now visible
- Device name + host shown as first line: `finn (100.64.0.1) ● online`
- Progress bars no longer wrap — if width too narrow, bars stack vertically instead of breaking

### 2. vLLM metrics in services table
For containers running vLLM, scrapes `/metrics` endpoint and shows:
- **Tok/s** — `vllm:avg_generation_throughput_toks_per_s` (1-min avg generation speed)
- **Prefill** — `vllm:avg_prompt_throughput_toks_per_s` (1-min avg prompt prefill speed)

Columns auto-hide when no vLLM services are running (smart column behavior).

### Pipeline
```
vLLM container /metrics → agent scrapeVLLMMetrics() → Container.VLLMMetrics
  → daemon aggregator → ContainerData → ServiceRow → service table columns
```

### Files changed (6)
- `agent/docker.go` — vLLM metric scraping + Container struct update
- `agent/metrics.go` — pass-through in metrics merge
- `agent/server.go` — include vLLM metrics in container listing
- `components/devicecard.go` — label fix + responsive bar layout
- `components/servicelist.go` — Tok/s + Prefill columns
- `views/dashboard.go` — wire vLLM metrics through ContainerData → ServiceRow