### PR TITLE
feat(deploy): select GGUF variant and pre-download shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,62 @@ All state lives in `~/.config/yokai/config.json`. Copy this file to another mach
 
 ---
 
+## Best Known Configurations (BKC)
+
+The BKC catalog is a library of pre-validated deploy recipes. Each entry pins the Docker image, tensor-parallel size, quantization flags, GPU memory utilization, chat template, tool-call parser, and any runtime options (`--ipc=host`, `--shm-size`, `ulimit`s) needed for a given model on a given GPU. The deploy wizard matches your model against the catalog, filters recipes by the target device's VRAM and GPU count, and offers one-click apply.
+
+**86 vLLM configs across 82 models from 23 publishers** (as of this commit). Entries are grouped by publisher and live in `internal/bkc/catalog_*.go`:
+
+| Publisher | Unique models | vLLM configs | Catalog file |
+|---|---:|---:|---|
+| `Qwen` | 20 | 20 | [`catalog_qwen.go`](internal/bkc/catalog_qwen.go) |
+| `nvidia` | 12 | 14 | [`catalog_nvidia.go`](internal/bkc/catalog_nvidia.go), [`catalog_llama.go`](internal/bkc/catalog_llama.go), [`catalog_moonshotai.go`](internal/bkc/catalog_moonshotai.go), [`catalog_qwen.go`](internal/bkc/catalog_qwen.go) |
+| `zai-org` (GLM) | 7 | 7 | [`catalog_glm.go`](internal/bkc/catalog_glm.go) |
+| `deepseek-ai` | 6 | 6 | [`catalog_deepseek.go`](internal/bkc/catalog_deepseek.go) |
+| `google` | 5 | 5 | [`catalog_google.go`](internal/bkc/catalog_google.go) |
+| `mistralai` | 5 | 5 | [`catalog_mistral.go`](internal/bkc/catalog_mistral.go) |
+| `baidu` (ERNIE) | 4 | 4 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `moonshotai` | 4 | 4 | [`catalog_moonshotai.go`](internal/bkc/catalog_moonshotai.go) |
+| `openai` | 2 | 4 | [`catalog_openai.go`](internal/bkc/catalog_openai.go) |
+| `meta-llama` | 2 | 2 | [`catalog_llama.go`](internal/bkc/catalog_llama.go) |
+| `internlm` | 2 | 2 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `tencent` | 2 | 2 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `microsoft` (Phi) | 1 | 1 | [`catalog_microsoft.go`](internal/bkc/catalog_microsoft.go) |
+| `amd` | 1 | 1 | [`catalog_openai.go`](internal/bkc/catalog_openai.go) |
+| `ByteDance-Seed` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `MiniMaxAI` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `OpenGVLab` (InternVL) | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `PaddlePaddle` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `XiaomiMiMo` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `arcee-ai` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `inclusionAI` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `jinaai` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| `stepfun-ai` | 1 | 1 | [`catalog_others.go`](internal/bkc/catalog_others.go) |
+| **Total** | **82** | **86** | |
+
+### Notable recipes
+
+- **Frontier reasoning / MoE** — DeepSeek R1 / V3.1 / V3.2 (FP8, 8× H200/B200), Qwen3-Coder-480B-A35B, Qwen3.5-397B-A17B-FP8, Qwen3-Next-80B-A3B (BF16 and FP8 variants), Moonshot Kimi K2.
+- **Gated Meta / NVIDIA** — Llama 3.3 70B (BF16 on Meta base, FP8 on Hopper, FP4 on Blackwell), nvidia/Llama-3.1-Nemotron-Ultra / Super, NGC images validated on DGX Spark GB10 and Jetson Thor (aarch64).
+- **Vision-language** — Qwen2.5-VL-7B/72B, Qwen3-VL-235B (BF16 + FP8), InternVL3.5-8B, ERNIE-4.5-VL-28B / VL-424B, PaddleOCR-VL, DeepSeek-OCR.
+- **Small / edge-friendly** — Qwen3-0.6B / 1.7B / 4B / 8B, Qwen3Guard-Gen-0.6B, Phi-4, Gemma 3 2B/4B/12B, validated for RTX 4090, RTX 5090, L40S, GB10, and Jetson Thor.
+- **AMD CDNA4** — `amd/gpt-oss-120b-w-mxfp4-a-fp8` tuned for MI355X with the ROCm vLLM image.
+
+### Device-aware selection
+
+BKC entries carry explicit hardware tags so the deploy wizard can hand you the right recipe for the device you selected:
+
+- NVIDIA: `gb10` (DGX Spark), `jetson-thor`, `rtx-pro-6000`, `rtx-5090`, `rtx-4090`, `l40s`, `a100-80`, `h100-80`, `h100-94`, `h200`, `h20`, `b200`, `gb200`
+- AMD: `mi300x`, `mi325x`, `mi355x`, `radeon-r9700`
+
+When multiple BKCs target the same model (e.g. Llama 3.3 70B has BF16, FP8, and FP4 variants), the daemon prefers the most specialised recipe whose `TargetDevices` include your device profile, then falls back to the first recipe whose `MinVRAMGBPerGPU` and `MinGPUCount` the device can satisfy.
+
+### Adding a BKC
+
+Drop a new entry into the appropriate `catalog_<vendor>.go` file (create one if your vendor doesn't have one yet) and register it in the `catalog` slice in `catalog_data.go`. Every entry needs a stable `ID`, a human-readable `Name`, the Docker image, port, exact runtime flags, and the hardware gates (`TargetDevices`, `MinVRAMGBPerGPU`, `MinGPUCount`, `Quantization`, `Arch`). See `catalog_llama.go` for a multi-variant example.
+
+---
+
 ## Supported Platforms
 
 ### User Machine (where you run `yokai`)

--- a/internal/agent/docker.go
+++ b/internal/agent/docker.go
@@ -55,17 +55,20 @@ type Container struct {
 
 // ContainerRequest represents a container deployment request.
 type ContainerRequest struct {
-	Image     string                `json:"image"`
-	Name      string                `json:"name"`
-	Model     string                `json:"model"`
-	Ports     map[string]string     `json:"ports"`
-	Env       map[string]string     `json:"env"`
-	GPUIDs    string                `json:"gpu_ids"`
-	ExtraArgs string                `json:"extra_args"`
-	Volumes   map[string]string     `json:"volumes"`
-	Plugins   []string              `json:"plugins"`
-	Runtime   config.RuntimeOptions `json:"runtime"`
-	SkipPull  bool                  `json:"skip_pull,omitempty"`
+	Image       string                `json:"image"`
+	Name        string                `json:"name"`
+	Model       string                `json:"model"`
+	GGUFVariant string                `json:"gguf_variant,omitempty"`
+	GGUFFiles   []string              `json:"gguf_files,omitempty"`
+	HFToken     string                `json:"hf_token,omitempty"`
+	Ports       map[string]string     `json:"ports"`
+	Env         map[string]string     `json:"env"`
+	GPUIDs      string                `json:"gpu_ids"`
+	ExtraArgs   string                `json:"extra_args"`
+	Volumes     map[string]string     `json:"volumes"`
+	Plugins     []string              `json:"plugins"`
+	Runtime     config.RuntimeOptions `json:"runtime"`
+	SkipPull    bool                  `json:"skip_pull,omitempty"`
 }
 
 // ContainerResponse represents a container deployment response.
@@ -186,13 +189,31 @@ func runContainer(req ContainerRequest) (*ContainerResponse, error) {
 	// Sanitize container name
 	containerName := fmt.Sprintf("yokai-%s", sanitizeName(req.Name))
 
+	// If the deploy targets a specific GGUF variant, pre-download every shard
+	// to the agent's shared models directory so the container can mmap the
+	// file(s) directly. The returned path is container-local (/models/...).
+	ggufPath, err := ensureGGUFFiles(&req)
+	if err != nil {
+		return nil, err
+	}
+	if ggufPath != "" {
+		if req.Volumes == nil {
+			req.Volumes = make(map[string]string)
+		}
+		ensureGGUFVolume(req.Volumes)
+	}
+
 	if isLlamaCppImage(req.Image) {
 		if req.Model != "" {
 			if req.Volumes == nil {
 				req.Volumes = make(map[string]string)
 			}
 			ensureModelsVolume(req.Volumes)
-			req.ExtraArgs = withLlamaModelArg(req.ExtraArgs, req.Model)
+			modelArg := req.Model
+			if ggufPath != "" {
+				modelArg = ggufPath
+			}
+			req.ExtraArgs = withLlamaModelArg(req.ExtraArgs, modelArg)
 		}
 		req.Ports = normalizeServicePorts(req.Ports, "8080")
 		req.ExtraArgs = withHostArg(req.ExtraArgs, "--host", "0.0.0.0")
@@ -204,7 +225,15 @@ func runContainer(req ContainerRequest) (*ContainerResponse, error) {
 				req.Volumes = make(map[string]string)
 			}
 			ensureHFCacheVolume(req.Volumes)
-			req.ExtraArgs = withVLLMModelArg(req.ExtraArgs, req.Model)
+			modelArg := req.Model
+			if ggufPath != "" {
+				// vLLM 0.6+ loads GGUF directly when --model points at the
+				// on-disk file. The tokenizer still resolves from the original
+				// HF repo unless the user overrode it in extra args.
+				modelArg = ggufPath
+				req.ExtraArgs = withVLLMTokenizerArg(req.ExtraArgs, req.Model)
+			}
+			req.ExtraArgs = withVLLMModelArg(req.ExtraArgs, modelArg)
 		}
 		req.Ports = normalizeServicePorts(req.Ports, "8000")
 		req.ExtraArgs = withHostArg(req.ExtraArgs, "--host", "0.0.0.0")
@@ -440,6 +469,23 @@ func ensurePluginAsset(pluginID string, asset plugins.Asset) error {
 		return fmt.Errorf("writing plugin asset %s: %w", hostPath, err)
 	}
 	return nil
+}
+
+// withVLLMTokenizerArg injects `--tokenizer <repo>` when the model arg is a
+// local GGUF path. Without this, vLLM tries to auto-load the tokenizer from
+// the file path, which fails since GGUF files do not ship a HF tokenizer
+// config. Callers should only invoke this when a GGUF variant is deployed.
+func withVLLMTokenizerArg(extraArgs, modelRepo string) string {
+	if modelRepo == "" {
+		return extraArgs
+	}
+	tokens := strings.Fields(extraArgs)
+	for _, t := range tokens {
+		if hasFlag(t, "--tokenizer") {
+			return extraArgs
+		}
+	}
+	return appendArg(extraArgs, fmt.Sprintf("--tokenizer %s", modelRepo))
 }
 
 func withVLLMModelArg(extraArgs, model string) string {

--- a/internal/agent/gguf.go
+++ b/internal/agent/gguf.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spencerbull/yokai/internal/hf"
+)
+
+// ggufHostDir is the directory on the agent host where downloaded GGUF shards
+// are stored. It is bind-mounted into the container as /models.
+const ggufHostDir = "/var/lib/yokai/models"
+
+// ggufContainerDir is where downloaded shards appear inside the container.
+const ggufContainerDir = "/models"
+
+// modelDirName is the unsafe-character-stripped subdirectory used to namespace
+// downloads per HuggingFace repo so two different repos don't collide on a
+// common filename like "model-Q4_K_M.gguf".
+var unsafeNameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func modelDirName(modelID string) string {
+	name := unsafeNameChars.ReplaceAllString(modelID, "_")
+	name = strings.Trim(name, "_")
+	if name == "" {
+		name = "model"
+	}
+	return name
+}
+
+// ensureGGUFFiles downloads every shard in req.GGUFFiles from HuggingFace to
+// the agent's local models directory. It returns the container-visible path
+// to the primary shard (the one that should be passed to the inference
+// runtime's --model flag).
+//
+// Already-downloaded shards are reused in place. Empty GGUFFiles is a no-op
+// and returns an empty path.
+func ensureGGUFFiles(req *ContainerRequest) (string, error) {
+	if len(req.GGUFFiles) == 0 {
+		return "", nil
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		return "", fmt.Errorf("gguf_files specified without a model repo id")
+	}
+
+	subdir := modelDirName(req.Model)
+	hostBase := filepath.Join(ggufHostDir, subdir)
+	if err := os.MkdirAll(hostBase, 0o755); err != nil {
+		return "", fmt.Errorf("creating %s: %w", hostBase, err)
+	}
+
+	dl := hf.NewDownloader(req.HFToken)
+	for _, filename := range req.GGUFFiles {
+		clean := strings.TrimSpace(filename)
+		if clean == "" {
+			continue
+		}
+		dest := filepath.Join(hostBase, filepath.Base(clean))
+		log.Printf("GGUF download: %s/%s -> %s", req.Model, clean, dest)
+		if err := dl.Download(req.Model, clean, dest); err != nil {
+			return "", fmt.Errorf("downloading %s: %w", clean, err)
+		}
+	}
+
+	primary := filepath.Base(strings.TrimSpace(req.GGUFFiles[0]))
+	return filepath.Join(ggufContainerDir, subdir, primary), nil
+}
+
+// ensureGGUFVolume guarantees the models volume is mounted at /models. This
+// is shared across llama.cpp and GGUF-based vLLM deploys so the downloaded
+// shards are visible inside the container.
+func ensureGGUFVolume(volumes map[string]string) {
+	for _, containerPath := range volumes {
+		if containerPath == ggufContainerDir {
+			return
+		}
+	}
+	volumes[ggufHostDir] = ggufContainerDir
+}

--- a/internal/agent/gguf.go
+++ b/internal/agent/gguf.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -33,9 +34,12 @@ func modelDirName(modelID string) string {
 }
 
 // ensureGGUFFiles downloads every shard in req.GGUFFiles from HuggingFace to
-// the agent's local models directory. It returns the container-visible path
-// to the primary shard (the one that should be passed to the inference
-// runtime's --model flag).
+// the agent's local models directory, preserving the repo's relative
+// directory structure so two files with the same basename in different
+// folders (common in repos that split one quant per directory) do not
+// overwrite each other. It returns the container-visible path to the primary
+// shard (the one that should be passed to the inference runtime's --model
+// flag).
 //
 // Already-downloaded shards are reused in place. Empty GGUFFiles is a no-op
 // and returns an empty path.
@@ -54,20 +58,65 @@ func ensureGGUFFiles(req *ContainerRequest) (string, error) {
 	}
 
 	dl := hf.NewDownloader(req.HFToken)
-	for _, filename := range req.GGUFFiles {
-		clean := strings.TrimSpace(filename)
-		if clean == "" {
+	primaryRel := ""
+	for i, filename := range req.GGUFFiles {
+		rel, err := sanitizeRepoPath(filename)
+		if err != nil {
+			return "", err
+		}
+		if rel == "" {
 			continue
 		}
-		dest := filepath.Join(hostBase, filepath.Base(clean))
-		log.Printf("GGUF download: %s/%s -> %s", req.Model, clean, dest)
-		if err := dl.Download(req.Model, clean, dest); err != nil {
-			return "", fmt.Errorf("downloading %s: %w", clean, err)
+		dest := filepath.Join(hostBase, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return "", fmt.Errorf("creating %s: %w", filepath.Dir(dest), err)
+		}
+		log.Printf("GGUF download: %s/%s -> %s", req.Model, rel, dest)
+		if err := dl.Download(req.Model, rel, dest); err != nil {
+			return "", fmt.Errorf("downloading %s: %w", rel, err)
+		}
+		if i == 0 {
+			primaryRel = rel
 		}
 	}
 
-	primary := filepath.Base(strings.TrimSpace(req.GGUFFiles[0]))
-	return filepath.Join(ggufContainerDir, subdir, primary), nil
+	if primaryRel == "" {
+		return "", nil
+	}
+	// Container path uses forward slashes regardless of the agent host OS.
+	return path.Join(ggufContainerDir, subdir, primaryRel), nil
+}
+
+// sanitizeRepoPath validates and normalizes a HuggingFace repo-relative path
+// before it is joined against a host directory. Rejects empty strings,
+// absolute paths, `..` segments, and Windows-style drive prefixes so a
+// malicious deploy request cannot escape the agent's models directory.
+func sanitizeRepoPath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", nil
+	}
+	// HuggingFace paths are always forward-slash; reject backslashes outright
+	// rather than silently normalising them.
+	if strings.ContainsRune(p, '\\') {
+		return "", fmt.Errorf("invalid gguf path %q: contains backslash", p)
+	}
+	if strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("invalid gguf path %q: must be relative", p)
+	}
+	clean := path.Clean(p)
+	if clean == "." || clean == "" {
+		return "", fmt.Errorf("invalid gguf path %q: empty after clean", p)
+	}
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("invalid gguf path %q: escapes repo root", p)
+	}
+	for _, segment := range strings.Split(clean, "/") {
+		if segment == ".." {
+			return "", fmt.Errorf("invalid gguf path %q: contains '..'", p)
+		}
+	}
+	return clean, nil
 }
 
 // ensureGGUFVolume guarantees the models volume is mounted at /models. This

--- a/internal/agent/gguf_test.go
+++ b/internal/agent/gguf_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import "testing"
+
+func TestSanitizeRepoPathAccepts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"model.gguf", "model.gguf"},
+		{"Q4_K_M/model-00001-of-00002.gguf", "Q4_K_M/model-00001-of-00002.gguf"},
+		{"nested/dir/model.gguf", "nested/dir/model.gguf"},
+		{"  Q4_K_M/model.gguf  ", "Q4_K_M/model.gguf"},
+		{"./model.gguf", "model.gguf"},
+	}
+	for _, tc := range cases {
+		got, err := sanitizeRepoPath(tc.in)
+		if err != nil {
+			t.Errorf("sanitizeRepoPath(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("sanitizeRepoPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSanitizeRepoPathRejects(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"/etc/passwd",
+		"../secret",
+		"Q4/../../../etc/passwd",
+		"..",
+		"foo\\bar.gguf",
+	}
+	for _, in := range cases {
+		if _, err := sanitizeRepoPath(in); err == nil {
+			t.Errorf("sanitizeRepoPath(%q) expected error, got none", in)
+		}
+	}
+}
+
+func TestSanitizeRepoPathEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := sanitizeRepoPath("   ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty result for whitespace input, got %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,19 +52,21 @@ func (d Device) SSHPortOrDefault() int {
 }
 
 type Service struct {
-	ID          string            `json:"id"`
-	DeviceID    string            `json:"device_id"`
-	Type        string            `json:"type"` // "vllm", "llamacpp", "comfyui"
-	Image       string            `json:"image"`
-	Model       string            `json:"model,omitempty"`
-	Port        int               `json:"port"`
-	GPUIDs      string            `json:"gpu_ids,omitempty"`
-	ExtraArgs   string            `json:"extra_args,omitempty"`
-	Env         map[string]string `json:"env,omitempty"`
-	Volumes     map[string]string `json:"volumes,omitempty"`
-	Plugins     []string          `json:"plugins,omitempty"`
-	Runtime     RuntimeOptions    `json:"runtime,omitempty"`
-	ContainerID string            `json:"container_id,omitempty"`
+	ID           string            `json:"id"`
+	DeviceID     string            `json:"device_id"`
+	Type         string            `json:"type"` // "vllm", "llamacpp", "comfyui"
+	Image        string            `json:"image"`
+	Model        string            `json:"model,omitempty"`
+	GGUFVariant  string            `json:"gguf_variant,omitempty"`
+	GGUFFiles    []string          `json:"gguf_files,omitempty"`
+	Port         int               `json:"port"`
+	GPUIDs       string            `json:"gpu_ids,omitempty"`
+	ExtraArgs    string            `json:"extra_args,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
+	Volumes      map[string]string `json:"volumes,omitempty"`
+	Plugins      []string          `json:"plugins,omitempty"`
+	Runtime      RuntimeOptions    `json:"runtime,omitempty"`
+	ContainerID  string            `json:"container_id,omitempty"`
 }
 
 type RuntimeOptions struct {

--- a/internal/daemon/aggregator.go
+++ b/internal/daemon/aggregator.go
@@ -27,6 +27,22 @@ type Aggregator struct {
 	client  *http.Client
 }
 
+// hfToken returns the HuggingFace token available to the daemon, falling back
+// to the environment when no value is configured. Used when forwarding deploy
+// requests that require downloading GGUF shards from the Hub.
+func (a *Aggregator) hfToken() string {
+	a.mu.RLock()
+	token := ""
+	if a.cfg != nil {
+		token = a.cfg.HFToken
+	}
+	a.mu.RUnlock()
+	if token == "" {
+		token = loadHFTokenFromEnv()
+	}
+	return token
+}
+
 // agentRequest creates an HTTP request with the agent's auth token (if configured).
 func (a *Aggregator) agentRequest(method, url, deviceID string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, body)
@@ -246,7 +262,18 @@ func (a *Aggregator) Deploy(req DeployRequest) (*DeployResult, error) {
 		return nil, fmt.Errorf("device %s is not connected", req.DeviceID)
 	}
 
-	jsonData, err := json.Marshal(req)
+	// Inject the HF token so the agent can fetch gated GGUF shards. The token
+	// is never persisted on the agent; it lives only for the duration of this
+	// deploy request.
+	payload := struct {
+		DeployRequest
+		HFToken string `json:"hf_token,omitempty"`
+	}{
+		DeployRequest: req,
+		HFToken:       a.hfToken(),
+	}
+
+	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling request: %w", err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -63,6 +63,7 @@ func Run(version string) error {
 	mux.HandleFunc("POST /bootstrap/device", d.handleBootstrapDevice)
 	mux.HandleFunc("GET /devices", d.handleDevices)
 	mux.HandleFunc("GET /hf/models", d.handleHFModels)
+	mux.HandleFunc("GET /hf/gguf-variants", d.handleHFGGUFVariants)
 	mux.HandleFunc("GET /deploy/bkc", d.handleDeployBKC)
 	mux.HandleFunc("POST /deploy/vllm-memory-estimate", d.handleVLLMMemoryEstimate)
 	mux.HandleFunc("POST /devices", d.handleCreateDevice)
@@ -423,6 +424,8 @@ func (d *Daemon) persistDeployResult(req DeployRequest, result *DeployResult) er
 		Type:        serviceType,
 		Image:       strings.TrimSpace(req.Image),
 		Model:       strings.TrimSpace(req.Model),
+		GGUFVariant: strings.TrimSpace(req.GGUFVariant),
+		GGUFFiles:   append([]string(nil), req.GGUFFiles...),
 		Port:        port,
 		GPUIDs:      strings.TrimSpace(req.GPUIDs),
 		ExtraArgs:   strings.TrimSpace(req.ExtraArgs),

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -9,6 +9,8 @@ type DeployRequest struct {
 	Image       string                `json:"image"`
 	Name        string                `json:"name"`
 	Model       string                `json:"model"`
+	GGUFVariant string                `json:"gguf_variant,omitempty"`
+	GGUFFiles   []string              `json:"gguf_files,omitempty"`
 	Ports       map[string]string     `json:"ports"`
 	Env         map[string]string     `json:"env"`
 	GPUIDs      string                `json:"gpu_ids"`

--- a/internal/daemon/ui_hf.go
+++ b/internal/daemon/ui_hf.go
@@ -7,6 +7,45 @@ import (
 	"github.com/spencerbull/yokai/internal/hf"
 )
 
+func (d *Daemon) currentHFToken() string {
+	d.mu.RLock()
+	token := d.cfg.HFToken
+	d.mu.RUnlock()
+	if token == "" {
+		token = loadHFTokenFromEnv()
+	}
+	return token
+}
+
+func (d *Daemon) handleHFGGUFVariants(w http.ResponseWriter, r *http.Request) {
+	model := strings.TrimSpace(r.URL.Query().Get("model"))
+	if model == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "model query param required",
+		})
+		return
+	}
+
+	variants, err := hf.NewClient(d.currentHFToken()).ListGGUFVariants(model)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":   "hf_variants_failed",
+			"message": err.Error(),
+		})
+		return
+	}
+
+	if variants == nil {
+		variants = []hf.GGUFVariant{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"model":    model,
+		"variants": variants,
+	})
+}
+
 func (d *Daemon) handleHFModels(w http.ResponseWriter, r *http.Request) {
 	query := strings.TrimSpace(r.URL.Query().Get("query"))
 	if len(query) < 2 {
@@ -20,15 +59,7 @@ func (d *Daemon) handleHFModels(w http.ResponseWriter, r *http.Request) {
 		filter = "text-generation"
 	}
 
-	token := ""
-	d.mu.RLock()
-	token = d.cfg.HFToken
-	d.mu.RUnlock()
-	if token == "" {
-		token = loadHFTokenFromEnv()
-	}
-
-	models, err := hf.NewClient(token).SearchModelsWithOptions(query, hf.SearchOptions{
+	models, err := hf.NewClient(d.currentHFToken()).SearchModelsWithOptions(query, hf.SearchOptions{
 		Limit:  30,
 		Filter: filter,
 	})

--- a/internal/hf/client.go
+++ b/internal/hf/client.go
@@ -103,7 +103,7 @@ func (c *Client) SearchModelsWithOptions(query string, opts SearchOptions) ([]Mo
 
 // ListGGUFFiles lists .gguf files in a model repo (for llama.cpp).
 func (c *Client) ListGGUFFiles(modelID string) ([]GGUFFile, error) {
-	reqURL := fmt.Sprintf("%s/models/%s/tree/main", baseURL, modelID)
+	reqURL := fmt.Sprintf("%s/models/%s/tree/main?recursive=1", baseURL, modelID)
 	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		return nil, err
@@ -141,6 +141,17 @@ func (c *Client) ListGGUFFiles(modelID string) ([]GGUFFile, error) {
 	}
 
 	return ggufFiles, nil
+}
+
+// ListGGUFVariants returns the GGUF files in a repo grouped by quantization.
+// Multi-shard variants collapse into a single GGUFVariant whose Shards field
+// lists every `<N>-of-<M>` file in order.
+func (c *Client) ListGGUFVariants(modelID string) ([]GGUFVariant, error) {
+	files, err := c.ListGGUFFiles(modelID)
+	if err != nil {
+		return nil, err
+	}
+	return GroupGGUFVariants(files), nil
 }
 
 // ValidateToken checks if the token is valid by hitting the whoami endpoint.

--- a/internal/hf/download.go
+++ b/internal/hf/download.go
@@ -1,0 +1,118 @@
+package hf
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileURL returns the public download URL for a file inside a HuggingFace
+// repository. The path is the repo-relative filename as returned by the tree
+// API.
+func FileURL(modelID, filename string) string {
+	return fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", modelID, filename)
+}
+
+// Downloader streams files from HuggingFace to local disk. Downloads that are
+// already complete (matching remote Content-Length) are a no-op.
+type Downloader struct {
+	Token  string
+	Client *http.Client
+}
+
+// NewDownloader creates a new Downloader. A long HTTP timeout is used so that
+// multi-gigabyte GGUF shards can complete.
+func NewDownloader(token string) *Downloader {
+	return &Downloader{
+		Token:  token,
+		Client: &http.Client{Timeout: 2 * time.Hour},
+	}
+}
+
+// Download writes the repo file at `filename` to `destPath`. Parent
+// directories are created as needed. When the destination already exists and
+// matches the remote Content-Length it is left untouched.
+func (d *Downloader) Download(modelID, filename, destPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("creating dest dir: %w", err)
+	}
+
+	remoteSize, err := d.headSize(modelID, filename)
+	if err == nil && remoteSize > 0 {
+		if info, statErr := os.Stat(destPath); statErr == nil && info.Size() == remoteSize {
+			return nil
+		}
+	}
+
+	req, err := http.NewRequest("GET", FileURL(modelID, filename), nil)
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	d.setAuth(req)
+
+	resp, err := d.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", filename, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("downloading %s: HTTP %d: %s", filename, resp.StatusCode, string(body))
+	}
+
+	tmp := destPath + ".partial"
+	out, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", tmp, err)
+	}
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("closing %s: %w", tmp, err)
+	}
+
+	if err := os.Rename(tmp, destPath); err != nil {
+		return fmt.Errorf("renaming %s: %w", tmp, err)
+	}
+	return nil
+}
+
+// headSize issues a HEAD request to discover the remote file size. A zero
+// return value indicates an unknown size (e.g. the HEAD endpoint redirected to
+// a streaming CDN that did not report Content-Length).
+func (d *Downloader) headSize(modelID, filename string) (int64, error) {
+	req, err := http.NewRequest("HEAD", FileURL(modelID, filename), nil)
+	if err != nil {
+		return 0, err
+	}
+	d.setAuth(req)
+
+	client := d.Client
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("HEAD %s: status %d", filename, resp.StatusCode)
+	}
+	return resp.ContentLength, nil
+}
+
+func (d *Downloader) setAuth(req *http.Request) {
+	if d.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+d.Token)
+	}
+}

--- a/internal/hf/gguf.go
+++ b/internal/hf/gguf.go
@@ -1,0 +1,182 @@
+package hf
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// GGUFVariant groups one or more GGUF shards that share the same quantization.
+type GGUFVariant struct {
+	// Quantization is the canonical quant label (e.g. "Q4_K_M", "F16"), or
+	// "unknown" if one could not be detected from the filenames.
+	Quantization string `json:"quantization"`
+	// Shards lists all files that make up this variant, sorted by shard index
+	// when a shard suffix is present. For single-file variants this holds a
+	// single entry.
+	Shards []GGUFFile `json:"shards"`
+	// ShardCount is the total number of shards discovered. For well-formed
+	// `<N>-of-<M>` suffixes this equals M; otherwise it is len(Shards).
+	ShardCount int `json:"shard_count"`
+	// TotalSizeMB sums the sizes of every shard in this variant.
+	TotalSizeMB int64 `json:"total_size_mb"`
+	// Primary is the filename the runtime (llama.cpp / vLLM) should be pointed
+	// at. For multi-shard variants this is the first shard (`00001-of-000NN`).
+	Primary string `json:"primary"`
+}
+
+// shardSuffixPattern matches the standard llama.cpp multi-file suffix:
+//
+//	name-00001-of-00003.gguf
+//
+// Captures: 1=index, 2=total
+var shardSuffixPattern = regexp.MustCompile(`(?i)-(\d{2,6})-of-(\d{2,6})\.gguf$`)
+
+// quantizationPatterns enumerates known GGUF quantization labels. The order is
+// longest-match-first so "Q4_K_M" wins over "Q4_K".
+var quantizationPatterns = []string{
+	// IQ (importance-matrix) quants
+	"IQ1_S", "IQ1_M",
+	"IQ2_XXS", "IQ2_XS", "IQ2_S", "IQ2_M",
+	"IQ3_XXS", "IQ3_XS", "IQ3_S", "IQ3_M",
+	"IQ4_XS", "IQ4_NL",
+	// K-quants
+	"Q2_K_S", "Q2_K",
+	"Q3_K_XL", "Q3_K_L", "Q3_K_M", "Q3_K_S", "Q3_K",
+	"Q4_K_XL", "Q4_K_M", "Q4_K_S", "Q4_K", "Q4_0", "Q4_1",
+	"Q5_K_M", "Q5_K_S", "Q5_K", "Q5_0", "Q5_1",
+	"Q6_K_XL", "Q6_K",
+	"Q8_K", "Q8_0",
+	// Ternary quants
+	"TQ1_0", "TQ2_0",
+	// Float formats
+	"BF16", "FP16", "F16", "FP32", "F32",
+}
+
+var quantTokenPattern = buildQuantTokenPattern()
+
+func buildQuantTokenPattern() *regexp.Regexp {
+	// Match the quant label delimited by a non-alphanumeric boundary on either
+	// side (hyphen, underscore, dot, or start/end). We allow `_` in the
+	// boundary because real filenames use it (e.g. `_Q4_K_M`), so the boundary
+	// before the label can be any non-letter.
+	escaped := make([]string, 0, len(quantizationPatterns))
+	for _, p := range quantizationPatterns {
+		escaped = append(escaped, regexp.QuoteMeta(p))
+	}
+	expr := `(?i)(?:^|[^A-Za-z0-9])(` + strings.Join(escaped, "|") + `)(?:[^A-Za-z0-9]|$)`
+	return regexp.MustCompile(expr)
+}
+
+// ParsedGGUFName holds the components extracted from a GGUF filename.
+type ParsedGGUFName struct {
+	Quantization string // canonical quant label, or "" if none matched
+	ShardIndex   int    // 1-based shard index, or 0 if not sharded
+	ShardTotal   int    // total shard count, or 0 if not sharded
+	Base         string // filename with the shard suffix removed; used as the
+	// grouping key so sibling shards land in the same variant.
+}
+
+// ParseGGUFFilename extracts the quantization and shard info from a GGUF
+// filename. The filename may include directory components; only the basename
+// is considered.
+func ParseGGUFFilename(filename string) ParsedGGUFName {
+	base := filename
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+
+	parsed := ParsedGGUFName{Base: base}
+
+	if match := shardSuffixPattern.FindStringSubmatchIndex(base); match != nil {
+		idx, _ := strconv.Atoi(base[match[2]:match[3]])
+		total, _ := strconv.Atoi(base[match[4]:match[5]])
+		parsed.ShardIndex = idx
+		parsed.ShardTotal = total
+		// Strip the shard suffix so siblings group together. Preserve the
+		// `.gguf` extension on the base key.
+		parsed.Base = base[:match[0]] + ".gguf"
+	}
+
+	// Run the quant match against the full original name (including shard
+	// suffix) since the quant label usually sits before the shard suffix.
+	if match := quantTokenPattern.FindStringSubmatch(base); len(match) == 2 {
+		parsed.Quantization = canonicalizeQuant(match[1])
+	}
+
+	return parsed
+}
+
+// canonicalizeQuant normalizes a matched quant token to its canonical upper
+// case form. F16/FP16 are treated as the same variant (FP16 is commonly used
+// by unsloth; F16 by llama.cpp). Likewise F32/FP32.
+func canonicalizeQuant(token string) string {
+	upper := strings.ToUpper(token)
+	switch upper {
+	case "FP16":
+		return "F16"
+	case "FP32":
+		return "F32"
+	}
+	return upper
+}
+
+// GroupGGUFVariants groups a flat list of GGUF files into variants, collapsing
+// shard siblings together. The returned list is sorted by quantization label.
+func GroupGGUFVariants(files []GGUFFile) []GGUFVariant {
+	type groupKey struct {
+		quant string
+		base  string
+	}
+
+	groups := make(map[groupKey]*GGUFVariant)
+	order := make([]groupKey, 0)
+
+	for _, f := range files {
+		parsed := ParseGGUFFilename(f.Filename)
+		quant := parsed.Quantization
+		if quant == "" {
+			quant = "unknown"
+		}
+		key := groupKey{quant: quant, base: parsed.Base}
+
+		variant, ok := groups[key]
+		if !ok {
+			variant = &GGUFVariant{Quantization: quant}
+			groups[key] = variant
+			order = append(order, key)
+		}
+		variant.Shards = append(variant.Shards, f)
+		variant.TotalSizeMB += f.SizeMB
+		if parsed.ShardTotal > variant.ShardCount {
+			variant.ShardCount = parsed.ShardTotal
+		}
+	}
+
+	result := make([]GGUFVariant, 0, len(order))
+	for _, key := range order {
+		variant := groups[key]
+		sort.SliceStable(variant.Shards, func(i, j int) bool {
+			a := ParseGGUFFilename(variant.Shards[i].Filename)
+			b := ParseGGUFFilename(variant.Shards[j].Filename)
+			if a.ShardIndex != b.ShardIndex {
+				return a.ShardIndex < b.ShardIndex
+			}
+			return variant.Shards[i].Filename < variant.Shards[j].Filename
+		})
+		if variant.ShardCount == 0 {
+			variant.ShardCount = len(variant.Shards)
+		}
+		if len(variant.Shards) > 0 {
+			variant.Primary = variant.Shards[0].Filename
+		}
+		result = append(result, *variant)
+	}
+
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].Quantization < result[j].Quantization
+	})
+
+	return result
+}

--- a/internal/hf/gguf.go
+++ b/internal/hf/gguf.go
@@ -79,30 +79,40 @@ type ParsedGGUFName struct {
 }
 
 // ParseGGUFFilename extracts the quantization and shard info from a GGUF
-// filename. The filename may include directory components; only the basename
-// is considered.
+// filename. The filename may include directory components; the directory
+// prefix is preserved in Base so files in different folders do not collide
+// during variant grouping (HuggingFace repos are listed recursively and
+// commonly keep one quant per subdirectory).
 func ParseGGUFFilename(filename string) ParsedGGUFName {
-	base := filename
-	if idx := strings.LastIndex(base, "/"); idx >= 0 {
-		base = base[idx+1:]
+	dir := ""
+	name := filename
+	if idx := strings.LastIndex(filename, "/"); idx >= 0 {
+		dir = filename[:idx+1]
+		name = filename[idx+1:]
 	}
 
-	parsed := ParsedGGUFName{Base: base}
+	parsed := ParsedGGUFName{Base: dir + name}
 
-	if match := shardSuffixPattern.FindStringSubmatchIndex(base); match != nil {
-		idx, _ := strconv.Atoi(base[match[2]:match[3]])
-		total, _ := strconv.Atoi(base[match[4]:match[5]])
+	if match := shardSuffixPattern.FindStringSubmatchIndex(name); match != nil {
+		idx, _ := strconv.Atoi(name[match[2]:match[3]])
+		total, _ := strconv.Atoi(name[match[4]:match[5]])
 		parsed.ShardIndex = idx
 		parsed.ShardTotal = total
 		// Strip the shard suffix so siblings group together. Preserve the
-		// `.gguf` extension on the base key.
-		parsed.Base = base[:match[0]] + ".gguf"
+		// `.gguf` extension and the directory prefix.
+		parsed.Base = dir + name[:match[0]] + ".gguf"
 	}
 
-	// Run the quant match against the full original name (including shard
-	// suffix) since the quant label usually sits before the shard suffix.
-	if match := quantTokenPattern.FindStringSubmatch(base); len(match) == 2 {
+	// Prefer the quant label from the basename, but fall back to the
+	// directory component — HuggingFace repos frequently name the folder
+	// after the quant (e.g. `Q4_K_M/model-00001-of-00002.gguf`) and give the
+	// shard files a generic `model-` prefix.
+	if match := quantTokenPattern.FindStringSubmatch(name); len(match) == 2 {
 		parsed.Quantization = canonicalizeQuant(match[1])
+	} else if dir != "" {
+		if match := quantTokenPattern.FindStringSubmatch(dir); len(match) == 2 {
+			parsed.Quantization = canonicalizeQuant(match[1])
+		}
 	}
 
 	return parsed

--- a/internal/hf/gguf_test.go
+++ b/internal/hf/gguf_test.go
@@ -47,6 +47,12 @@ func TestParseGGUFFilenameShard(t *testing.T) {
 		{"Qwen3-27B-Q4_K_M-00002-of-00003.gguf", 2, 3, "Qwen3-27B-Q4_K_M.gguf"},
 		{"model-00003-OF-00003.gguf", 3, 3, "model.gguf"},
 		{"model-Q4_K_M.gguf", 0, 0, "model-Q4_K_M.gguf"},
+		// Directory-prefixed paths from a recursive HF tree listing: the
+		// directory stays in Base so sibling shards in the same folder group,
+		// while same-basename files in different folders stay separate.
+		{"Q4_K_M/model-00001-of-00003.gguf", 1, 3, "Q4_K_M/model.gguf"},
+		{"F16/model-00001-of-00002.gguf", 1, 2, "F16/model.gguf"},
+		{"nested/dir/model.gguf", 0, 0, "nested/dir/model.gguf"},
 	}
 
 	for _, tc := range cases {
@@ -57,6 +63,46 @@ func TestParseGGUFFilenameShard(t *testing.T) {
 		if got.Base != tc.base {
 			t.Errorf("%s: expected base %q, got %q", tc.filename, tc.base, got.Base)
 		}
+	}
+}
+
+func TestGroupGGUFVariantsPreservesDirectoryContext(t *testing.T) {
+	t.Parallel()
+
+	// Real-world repo layout where each quant lives in its own folder and the
+	// shards all share the same basename. Without directory-aware grouping
+	// these would collapse into one oversized variant.
+	files := []GGUFFile{
+		{Filename: "Q4_K_M/model-00001-of-00002.gguf", SizeMB: 8000},
+		{Filename: "Q4_K_M/model-00002-of-00002.gguf", SizeMB: 8000},
+		{Filename: "Q8_0/model-00001-of-00002.gguf", SizeMB: 14000},
+		{Filename: "Q8_0/model-00002-of-00002.gguf", SizeMB: 14000},
+	}
+
+	variants := GroupGGUFVariants(files)
+	if len(variants) != 2 {
+		t.Fatalf("expected 2 variants, got %d: %+v", len(variants), variants)
+	}
+
+	index := make(map[string]GGUFVariant, len(variants))
+	for _, v := range variants {
+		index[v.Quantization] = v
+	}
+
+	q4 := index["Q4_K_M"]
+	if q4.ShardCount != 2 || len(q4.Shards) != 2 || q4.TotalSizeMB != 16000 {
+		t.Errorf("Q4_K_M: unexpected variant %+v", q4)
+	}
+	if q4.Primary != "Q4_K_M/model-00001-of-00002.gguf" {
+		t.Errorf("Q4_K_M: expected primary with directory prefix, got %q", q4.Primary)
+	}
+
+	q8 := index["Q8_0"]
+	if q8.ShardCount != 2 || len(q8.Shards) != 2 || q8.TotalSizeMB != 28000 {
+		t.Errorf("Q8_0: unexpected variant %+v", q8)
+	}
+	if q8.Primary != "Q8_0/model-00001-of-00002.gguf" {
+		t.Errorf("Q8_0: expected primary with directory prefix, got %q", q8.Primary)
 	}
 }
 

--- a/internal/hf/gguf_test.go
+++ b/internal/hf/gguf_test.go
@@ -1,0 +1,167 @@
+package hf
+
+import (
+	"testing"
+)
+
+func TestParseGGUFFilenameQuant(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		filename string
+		quant    string
+	}{
+		{"Qwen3-27B-Instruct-Q4_K_M.gguf", "Q4_K_M"},
+		{"qwen3-27b-instruct-q4_k_m.gguf", "Q4_K_M"},
+		{"Qwen3-27B-Instruct.Q8_0.gguf", "Q8_0"},
+		{"model-f16.gguf", "F16"},
+		{"model-FP16.gguf", "F16"},
+		{"model-bf16.gguf", "BF16"},
+		{"model-IQ4_XS.gguf", "IQ4_XS"},
+		{"Qwen3-27B-IQ2_M.gguf", "IQ2_M"},
+		{"llama-3-Q4_K.gguf", "Q4_K"},
+		{"llama-3-Q4_K_S.gguf", "Q4_K_S"},
+		{"llama-3-Q6_K.gguf", "Q6_K"},
+		{"model.gguf", ""},
+		{"config.json", ""},
+	}
+
+	for _, tc := range cases {
+		got := ParseGGUFFilename(tc.filename).Quantization
+		if got != tc.quant {
+			t.Errorf("%s: expected quant %q, got %q", tc.filename, tc.quant, got)
+		}
+	}
+}
+
+func TestParseGGUFFilenameShard(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		filename string
+		index    int
+		total    int
+		base     string
+	}{
+		{"Qwen3-27B-Q4_K_M-00001-of-00003.gguf", 1, 3, "Qwen3-27B-Q4_K_M.gguf"},
+		{"Qwen3-27B-Q4_K_M-00002-of-00003.gguf", 2, 3, "Qwen3-27B-Q4_K_M.gguf"},
+		{"model-00003-OF-00003.gguf", 3, 3, "model.gguf"},
+		{"model-Q4_K_M.gguf", 0, 0, "model-Q4_K_M.gguf"},
+	}
+
+	for _, tc := range cases {
+		got := ParseGGUFFilename(tc.filename)
+		if got.ShardIndex != tc.index || got.ShardTotal != tc.total {
+			t.Errorf("%s: expected shard %d/%d, got %d/%d", tc.filename, tc.index, tc.total, got.ShardIndex, got.ShardTotal)
+		}
+		if got.Base != tc.base {
+			t.Errorf("%s: expected base %q, got %q", tc.filename, tc.base, got.Base)
+		}
+	}
+}
+
+func TestGroupGGUFVariantsSingleFile(t *testing.T) {
+	t.Parallel()
+
+	files := []GGUFFile{
+		{Filename: "Qwen3-27B-Q4_K_M.gguf", SizeMB: 16000},
+		{Filename: "Qwen3-27B-Q8_0.gguf", SizeMB: 28000},
+		{Filename: "Qwen3-27B-F16.gguf", SizeMB: 54000},
+	}
+
+	variants := GroupGGUFVariants(files)
+	if len(variants) != 3 {
+		t.Fatalf("expected 3 variants, got %d", len(variants))
+	}
+
+	index := make(map[string]GGUFVariant, len(variants))
+	for _, v := range variants {
+		index[v.Quantization] = v
+	}
+
+	q4 := index["Q4_K_M"]
+	if q4.ShardCount != 1 || len(q4.Shards) != 1 || q4.Primary != "Qwen3-27B-Q4_K_M.gguf" {
+		t.Errorf("Q4_K_M: unexpected variant %+v", q4)
+	}
+	if q4.TotalSizeMB != 16000 {
+		t.Errorf("Q4_K_M: expected total 16000MB, got %d", q4.TotalSizeMB)
+	}
+
+	f16 := index["F16"]
+	if f16.Primary != "Qwen3-27B-F16.gguf" || f16.TotalSizeMB != 54000 {
+		t.Errorf("F16: unexpected variant %+v", f16)
+	}
+}
+
+func TestGroupGGUFVariantsSharded(t *testing.T) {
+	t.Parallel()
+
+	// Shards arrive in non-sequential order; grouping should re-sort them.
+	files := []GGUFFile{
+		{Filename: "Qwen3-27B-Q4_K_M-00002-of-00003.gguf", SizeMB: 16000},
+		{Filename: "Qwen3-27B-Q4_K_M-00001-of-00003.gguf", SizeMB: 16000},
+		{Filename: "Qwen3-27B-Q4_K_M-00003-of-00003.gguf", SizeMB: 12000},
+		{Filename: "Qwen3-27B-F16-00001-of-00002.gguf", SizeMB: 30000},
+		{Filename: "Qwen3-27B-F16-00002-of-00002.gguf", SizeMB: 24000},
+	}
+
+	variants := GroupGGUFVariants(files)
+	if len(variants) != 2 {
+		t.Fatalf("expected 2 variants, got %d", len(variants))
+	}
+
+	index := make(map[string]GGUFVariant, len(variants))
+	for _, v := range variants {
+		index[v.Quantization] = v
+	}
+
+	q4 := index["Q4_K_M"]
+	if q4.ShardCount != 3 {
+		t.Errorf("Q4_K_M: expected shard count 3, got %d", q4.ShardCount)
+	}
+	if len(q4.Shards) != 3 {
+		t.Errorf("Q4_K_M: expected 3 shards, got %d", len(q4.Shards))
+	}
+	if q4.Primary != "Qwen3-27B-Q4_K_M-00001-of-00003.gguf" {
+		t.Errorf("Q4_K_M: expected primary to be first shard, got %q", q4.Primary)
+	}
+	if q4.TotalSizeMB != 44000 {
+		t.Errorf("Q4_K_M: expected total 44000MB, got %d", q4.TotalSizeMB)
+	}
+	for i, shard := range q4.Shards {
+		expected := []string{
+			"Qwen3-27B-Q4_K_M-00001-of-00003.gguf",
+			"Qwen3-27B-Q4_K_M-00002-of-00003.gguf",
+			"Qwen3-27B-Q4_K_M-00003-of-00003.gguf",
+		}[i]
+		if shard.Filename != expected {
+			t.Errorf("Q4_K_M: shard %d = %q, want %q", i, shard.Filename, expected)
+		}
+	}
+
+	f16 := index["F16"]
+	if f16.ShardCount != 2 || len(f16.Shards) != 2 {
+		t.Errorf("F16: expected 2 shards, got shardCount=%d shards=%d", f16.ShardCount, len(f16.Shards))
+	}
+	if f16.Primary != "Qwen3-27B-F16-00001-of-00002.gguf" {
+		t.Errorf("F16: expected primary to be first shard, got %q", f16.Primary)
+	}
+}
+
+func TestGroupGGUFVariantsUnknownQuant(t *testing.T) {
+	t.Parallel()
+
+	files := []GGUFFile{
+		{Filename: "model.gguf", SizeMB: 1024},
+	}
+	variants := GroupGGUFVariants(files)
+	if len(variants) != 1 {
+		t.Fatalf("expected 1 variant, got %d", len(variants))
+	}
+	if variants[0].Quantization != "unknown" {
+		t.Errorf("expected unknown quant, got %q", variants[0].Quantization)
+	}
+	if variants[0].Primary != "model.gguf" {
+		t.Errorf("expected primary model.gguf, got %q", variants[0].Primary)
+	}
+}

--- a/ui/tui/src/contracts/deploy.ts
+++ b/ui/tui/src/contracts/deploy.ts
@@ -14,9 +14,29 @@ export type DeployForm = {
   extraArgs: string
   image: string
   model: string
+  ggufVariant: string
+  ggufFiles: string[]
   name: string
   port: string
   workload: WorkloadType
+}
+
+export type GGUFFile = {
+  rfilename: string
+  SizeMB?: number
+}
+
+export type GGUFVariant = {
+  quantization: string
+  shards: GGUFFile[]
+  shard_count: number
+  total_size_mb: number
+  primary: string
+}
+
+export type GGUFVariantsResponse = {
+  model: string
+  variants: GGUFVariant[]
 }
 
 export type DeployRequest = {
@@ -25,6 +45,8 @@ export type DeployRequest = {
   image: string
   name: string
   model: string
+  gguf_variant?: string
+  gguf_files?: string[]
   ports: Record<string, string>
   env: Record<string, string>
   gpu_ids: string

--- a/ui/tui/src/features/deploy/DeployRoute.tsx
+++ b/ui/tui/src/features/deploy/DeployRoute.tsx
@@ -10,7 +10,7 @@ type DeployRouteProps = {
   terminalHeight?: number
 }
 
-const STEP_LABELS = ["Workload", "Device", "Image", "Model", "Config", "Deploy"]
+const STEP_LABELS = ["Workload", "Device", "Image", "Model", "Variant", "Config", "Deploy"]
 
 export function DeployRoute(props: DeployRouteProps) {
   const theme = useTheme()
@@ -54,6 +54,7 @@ export function DeployRoute(props: DeployRouteProps) {
           <Line label="Device" value={props.controller.form.deviceId || "-"} />
           <Line label="Image" value={props.controller.form.image || "-"} />
           <Line label="Model" value={props.controller.form.workload === "comfyui" ? "n/a" : props.controller.form.model || "-"} />
+          <Line label="Variant" value={props.controller.form.workload === "comfyui" ? "n/a" : variantSummary(props.controller.form.ggufVariant, props.controller.form.ggufFiles.length)} />
           <Line label="Port" value={props.controller.form.port || "-"} />
           <Line label="Args" value={firstArgLine(props.controller.form.extraArgs) || "-"} />
           <text fg={theme.colors.textSubtle}>Use Esc to go back a step.</text>
@@ -74,6 +75,8 @@ function renderStep(controller: DeployController) {
       return <ImageStep controller={controller} />
     case "model":
       return <ModelStep controller={controller} />
+    case "variant":
+      return <VariantStep controller={controller} />
     case "config":
       return <ConfigStep controller={controller} />
     default:
@@ -170,6 +173,64 @@ function ModelStep(props: { controller: DeployController }) {
       {history.map((model) => (
         <ActionChip key={model} onSelect={() => props.controller.setValue("model", model)}>{model}</ActionChip>
       ))}
+    </box>
+  )
+}
+
+function VariantStep(props: { controller: DeployController }) {
+  const theme = useTheme()
+  const variants = props.controller.ggufVariants
+
+  if (props.controller.ggufLoading) {
+    return <text fg={theme.colors.textMuted}>Looking up GGUF variants for {props.controller.form.model}...</text>
+  }
+
+  if (props.controller.ggufError) {
+    return (
+      <box flexDirection="column" gap={1}>
+        <text fg={theme.colors.warning}>Could not list GGUF variants: {props.controller.ggufError}</text>
+        <text fg={theme.colors.textSubtle}>Press Enter or S to skip and continue without a pre-downloaded variant.</text>
+      </box>
+    )
+  }
+
+  if (variants.length === 0) {
+    return (
+      <box flexDirection="column" gap={1}>
+        <text fg={theme.colors.textMuted}>No GGUF files were found in this repo.</text>
+        <text fg={theme.colors.textSubtle}>Press Enter to continue. The container will load the model directly.</text>
+      </box>
+    )
+  }
+
+  return (
+    <box flexDirection="column" gap={1}>
+      <text fg={theme.colors.textMuted}>Choose a GGUF quantization. All shards for the selected variant are downloaded to the device before the container starts.</text>
+      {variants.map((variant, index) => {
+        const highlighted = index === props.controller.cursor
+        const selected = props.controller.form.ggufVariant === variant.quantization
+        const sizeGB = (variant.total_size_mb / 1024).toFixed(1)
+        const shardLabel = variant.shard_count > 1 ? `${variant.shard_count} shards` : "single file"
+        return (
+          <box
+            key={`${variant.quantization}-${variant.primary}`}
+            border
+            borderStyle={selected ? "double" : "single"}
+            borderColor={selected ? theme.colors.borderStrong : highlighted ? theme.colors.accent : theme.colors.border}
+            backgroundColor={theme.colors.panel}
+            padding={1}
+            flexDirection="column"
+            onMouseDown={() => props.controller.selectVariant(index)}
+          >
+            <text fg={selected ? theme.colors.accent : theme.colors.text}>
+              <strong>{highlighted ? `▸ ${variant.quantization}` : variant.quantization}</strong>
+              <span fg={theme.colors.textMuted}> · {sizeGB} GB · {shardLabel}</span>
+            </text>
+            <text fg={theme.colors.textSubtle}>{variant.primary}</text>
+          </box>
+        )
+      })}
+      <text fg={theme.colors.textSubtle}>Arrow keys or j/k choose. Enter selects. S skips. Esc returns to Model.</text>
     </box>
   )
 }
@@ -388,6 +449,16 @@ function formatArgsPreview(args: string) {
 
 function firstArgLine(args: string) {
   return formatArgsPreview(args)[0] ?? ""
+}
+
+function variantSummary(quant: string, shardCount: number) {
+  if (!quant) {
+    return "-"
+  }
+  if (shardCount > 1) {
+    return `${quant} (${shardCount} shards)`
+  }
+  return quant
 }
 
 function noticeColor(theme: ReturnType<typeof useTheme>, level: "info" | "success" | "warning" | "error") {

--- a/ui/tui/src/features/deploy/useDeployController.ts
+++ b/ui/tui/src/features/deploy/useDeployController.ts
@@ -1,11 +1,11 @@
 import { startTransition, useEffect, useMemo, useState } from "react"
 
-import type { DeployBKC, DeployForm, HFModel, VLLMMemoryEstimate, WorkloadType } from "../../contracts/deploy"
+import type { DeployBKC, DeployForm, GGUFVariant, HFModel, VLLMMemoryEstimate, WorkloadType } from "../../contracts/deploy"
 import type { DeviceRecord } from "../../contracts/fleet"
 import type { SettingsDocument } from "../../contracts/settings"
-import { deployService, getDeployBKC, getDevices, getHFModels, getSettings, getVLLMMemoryEstimate, putDeployHistory } from "../../services/daemon-client"
+import { deployService, getDeployBKC, getDevices, getGGUFVariants, getHFModels, getSettings, getVLLMMemoryEstimate, putDeployHistory } from "../../services/daemon-client"
 
-type DeployStep = "workload" | "device" | "image" | "model" | "config" | "review"
+type DeployStep = "workload" | "device" | "image" | "model" | "variant" | "config" | "review"
 type ConfigField = "port" | "extraArgs" | "bkcAction" | "contextLength" | "overheadGB" | "hfmemCalculate" | "hfmemApply"
 type ReviewAction = "back" | "deploy"
 
@@ -27,7 +27,7 @@ type KeyLike = {
   shift?: boolean
 }
 
-const STEPS: DeployStep[] = ["workload", "device", "image", "model", "config", "review"]
+const STEPS: DeployStep[] = ["workload", "device", "image", "model", "variant", "config", "review"]
 const WORKLOADS: WorkloadType[] = ["vllm", "llamacpp", "comfyui"]
 
 const EMPTY_SETTINGS: SettingsDocument = {
@@ -62,6 +62,9 @@ export function useDeployController(active: boolean, onComplete: () => void) {
   const [searchError, setSearchError] = useState<string>()
   const [bkc, setBkc] = useState<DeployBKC | null>(null)
   const [appliedBKCId, setAppliedBKCId] = useState("")
+  const [ggufVariants, setGGUFVariants] = useState<GGUFVariant[]>([])
+  const [ggufLoading, setGGUFLoading] = useState(false)
+  const [ggufError, setGGUFError] = useState<string>()
   const [vllmHelper, setVLLMHelper] = useState<VLLMHelperState>({
     contextLength: "32768",
     estimate: null,
@@ -175,6 +178,43 @@ export function useDeployController(active: boolean, onComplete: () => void) {
   }, [active, form.deviceId, form.model, form.workload])
 
   useEffect(() => {
+    if (!active) {
+      return
+    }
+    if (form.workload === "comfyui") {
+      setGGUFVariants([])
+      setGGUFError(undefined)
+      return
+    }
+    const model = form.model.trim()
+    if (model === "") {
+      setGGUFVariants([])
+      setGGUFError(undefined)
+      return
+    }
+
+    let cancelled = false
+    setGGUFLoading(true)
+    setGGUFError(undefined)
+    void getGGUFVariants(model)
+      .then((variants) => {
+        if (cancelled) return
+        setGGUFVariants(variants)
+        setGGUFLoading(false)
+      })
+      .catch((cause) => {
+        if (cancelled) return
+        setGGUFVariants([])
+        setGGUFError(cause instanceof Error ? cause.message : "failed to fetch GGUF variants")
+        setGGUFLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [active, form.model, form.workload])
+
+  useEffect(() => {
     if (!notice) {
       return
     }
@@ -190,12 +230,48 @@ export function useDeployController(active: boolean, onComplete: () => void) {
     secondary: device.host,
   })), [devices])
 
+  function advanceFromModel() {
+    if (form.workload === "comfyui") {
+      setStep("config")
+      setCursor(0)
+      return
+    }
+    // Go to variant step when variants are known and non-empty, or when a
+    // request is still in flight so the user sees the spinner. If the repo
+    // has no GGUF files, skip the step entirely.
+    if (ggufLoading || ggufVariants.length > 0) {
+      setStep("variant")
+      setCursor(0)
+      return
+    }
+    setStep("config")
+    setCursor(0)
+  }
+
+  function selectVariantByIndex(index: number) {
+    const variant = ggufVariants[index]
+    if (!variant) {
+      return
+    }
+    const files = variant.shards.map((shard) => shard.rfilename)
+    setForm((current) => ({
+      ...current,
+      ggufVariant: variant.quantization,
+      ggufFiles: files,
+    }))
+    setStep("config")
+    setCursor(0)
+  }
+
   return {
     activeBKC: bkc && appliedBKCId === bkc.id ? bkc : null,
     availableBKC: bkc,
     applyBKC() {
       applyBKCToForm()
     },
+    ggufVariants,
+    ggufLoading,
+    ggufError,
     configField,
     cursor,
     calculateVLLMMemory: () => void calculateVLLMMemory(),
@@ -203,7 +279,7 @@ export function useDeployController(active: boolean, onComplete: () => void) {
     form,
     extraArgsEditing,
     hasAppliedBKC: Boolean(bkc && appliedBKCId === bkc.id),
-    locksGlobalNav: step === "image" || step === "model" || step === "config",
+    locksGlobalNav: step === "image" || step === "model" || step === "variant" || step === "config",
     modelResults,
     notice,
     pendingAction,
@@ -235,6 +311,8 @@ export function useDeployController(active: boolean, onComplete: () => void) {
           return handleImageKey(key)
         case "model":
           return handleModelKey(key)
+        case "variant":
+          return handleVariantKey(key)
         case "config":
           return handleConfigKey(key)
         case "review":
@@ -252,10 +330,22 @@ export function useDeployController(active: boolean, onComplete: () => void) {
       setReviewAction(action)
     },
     selectModel(modelId: string) {
-      setForm((current) => ({ ...current, model: modelId }))
-      setStep("config")
+      setForm((current) => ({ ...current, model: modelId, ggufVariant: "", ggufFiles: [] }))
       setSearchError(undefined)
       setModelResults([])
+      // Defer the step advance to the next render so the new model has a
+      // chance to kick off the variants fetch; the flow tries to route via
+      // the variant step when any variants exist.
+      if (form.workload === "comfyui") {
+        setStep("config")
+        setCursor(0)
+        return
+      }
+      setStep("variant")
+      setCursor(0)
+    },
+    selectVariant(index: number) {
+      selectVariantByIndex(index)
     },
     selectWorkload(workload: WorkloadType) {
       setForm((current) => applyWorkloadDefaults(current, settings, workload))
@@ -362,14 +452,46 @@ export function useDeployController(active: boolean, onComplete: () => void) {
       case "return":
       case "enter":
         if (modelResults.length > 0 && cursor < modelResults.length) {
-          setForm((current) => ({ ...current, model: modelResults[cursor].id }))
+          setForm((current) => ({ ...current, model: modelResults[cursor].id, ggufVariant: "", ggufFiles: [] }))
         }
         if (form.model.trim() === "") {
           setNotice({ level: "error", message: "Model is required" })
           return true
         }
+        advanceFromModel()
+        return true
+      default:
+        return false
+    }
+  }
+
+  function handleVariantKey(key: KeyLike) {
+    switch (key.name) {
+      case "escape":
+        setStep("model")
+        return true
+      case "up":
+      case "k":
+        setCursor((current) => Math.max(0, current - 1))
+        return true
+      case "down":
+      case "j":
+        setCursor((current) => Math.min(Math.max(0, ggufVariants.length - 1), current + 1))
+        return true
+      case "s":
+        // Skip variant selection (deploy without pre-downloading GGUF files).
+        setForm((current) => ({ ...current, ggufVariant: "", ggufFiles: [] }))
         setStep("config")
         setCursor(0)
+        return true
+      case "return":
+      case "enter":
+        if (ggufVariants.length === 0) {
+          setStep("config")
+          setCursor(0)
+          return true
+        }
+        selectVariantByIndex(cursor)
         return true
       default:
         return false
@@ -383,7 +505,13 @@ export function useDeployController(active: boolean, onComplete: () => void) {
 
     switch (key.name) {
       case "escape":
-        setStep(form.workload === "comfyui" ? "image" : "model")
+        if (form.workload === "comfyui") {
+          setStep("image")
+        } else if (ggufVariants.length > 0) {
+          setStep("variant")
+        } else {
+          setStep("model")
+        }
         return true
       case "tab":
         setConfigField((current) => nextConfigField(current, form.workload, key.shift ? -1 : 1))
@@ -565,6 +693,8 @@ function emptyForm(): DeployForm {
     extraArgs: "",
     image: "",
     model: "",
+    ggufVariant: "",
+    ggufFiles: [],
     name: "",
     port: "8000",
     workload: "vllm",
@@ -576,6 +706,7 @@ function applyDefaults(form: DeployForm, settings: SettingsDocument) {
 }
 
 function applyWorkloadDefaults(form: DeployForm, settings: SettingsDocument, workload: WorkloadType): DeployForm {
+  const resetGGUF = workload !== form.workload
   switch (workload) {
     case "llamacpp":
       return {
@@ -584,6 +715,8 @@ function applyWorkloadDefaults(form: DeployForm, settings: SettingsDocument, wor
         name: defaultName(workload, form.model),
         port: "8080",
         extraArgs: workload === form.workload ? form.extraArgs : "",
+        ggufVariant: resetGGUF ? "" : form.ggufVariant,
+        ggufFiles: resetGGUF ? [] : form.ggufFiles,
         workload,
       }
     case "comfyui":
@@ -594,6 +727,8 @@ function applyWorkloadDefaults(form: DeployForm, settings: SettingsDocument, wor
         name: defaultName(workload, "comfyui"),
         port: "8188",
         extraArgs: workload === form.workload ? form.extraArgs : "",
+        ggufVariant: "",
+        ggufFiles: [],
         workload,
       }
     default:
@@ -603,6 +738,8 @@ function applyWorkloadDefaults(form: DeployForm, settings: SettingsDocument, wor
         name: defaultName(workload, form.model),
         port: "8000",
         extraArgs: workload === form.workload ? form.extraArgs : "",
+        ggufVariant: resetGGUF ? "" : form.ggufVariant,
+        ggufFiles: resetGGUF ? [] : form.ggufFiles,
         workload,
       }
   }
@@ -630,6 +767,8 @@ function buildDeployRequest(form: DeployForm, bkc: DeployBKC | null) {
     image: form.image.trim(),
     name: defaultName(form.workload, form.model),
     model: form.workload === "comfyui" ? "" : form.model.trim(),
+    gguf_variant: form.ggufVariant || undefined,
+    gguf_files: form.ggufFiles.length > 0 ? [...form.ggufFiles] : undefined,
     ports: { [port]: port },
     env: cloneMap(bkc?.env),
     gpu_ids: "all",

--- a/ui/tui/src/services/daemon-client.ts
+++ b/ui/tui/src/services/daemon-client.ts
@@ -1,6 +1,6 @@
 import { DAEMON_URL } from "../config"
 import type { BootstrapDeviceRequest, BootstrapDeviceResponse, BulkDeviceTestResponse, BulkDeviceUpgradeResponse, DeviceDeleteResult, DeviceRequest, DeviceTestResult, DeviceUpgradeResult, SSHConfigHostsResponse, TailscalePeersResponse, TailscaleStatus } from "../contracts/devices"
-import type { DeployBKC, DeployRequest, DeployResult, HFModel, VLLMMemoryEstimate, WorkloadType } from "../contracts/deploy"
+import type { DeployBKC, DeployRequest, DeployResult, GGUFVariantsResponse, HFModel, VLLMMemoryEstimate, WorkloadType } from "../contracts/deploy"
 import type { DevicesResponse, LogTarget, MetricsResponse } from "../contracts/fleet"
 import type { DeployHistory, HFSettings, HFTokenValidation, IntegrationsConfigureRequest, IntegrationsConfigureResponse, OpenAIEndpoint, SettingsDocument, SettingsPatch } from "../contracts/settings"
 import { readSSEStream } from "./sse"
@@ -59,6 +59,11 @@ export async function getMetrics() {
 export async function getHFModels(query: string, workload: WorkloadType) {
   const response = await daemonRequest<{ models: HFModel[] }>(`/hf/models?query=${encodeURIComponent(query)}&workload=${encodeURIComponent(workload)}`)
   return response.models ?? []
+}
+
+export async function getGGUFVariants(model: string) {
+  const response = await daemonRequest<GGUFVariantsResponse>(`/hf/gguf-variants?model=${encodeURIComponent(model)}`)
+  return response.variants ?? []
 }
 
 export async function getDeployBKC(workload: WorkloadType, model: string, deviceId?: string) {


### PR DESCRIPTION
## Summary

When deploying a GGUF repo (e.g. `unsloth/Qwen3-27B-GGUF`) for vLLM or
llama.cpp, the deploy flow now lists every quantization variant in the
repo, groups multi-file shards together, and pre-downloads the full
shard set for the chosen variant to the agent's `/var/lib/yokai/models`
volume before the container starts. The runtime is pointed at the local
file path (`/models/<repo>/<shard>`) instead of the bare repo id.

## Backend (`internal/hf`, `internal/daemon`, `internal/agent`)

- `internal/hf/gguf.go`: parses quant labels (`Q4_K_M`, `IQ4_XS`,
  `F16`/`FP16` normalized, `BF16`, …) and `-00001-of-00003.gguf` shard
  suffixes. `GroupGGUFVariants` collapses sibling shards into one
  variant sorted by shard index.
- `internal/hf/client.go`: new `ListGGUFVariants` built on the existing
  `ListGGUFFiles` (now recursive so nested folders are picked up).
- `internal/hf/download.go`: `Downloader` streams files from
  `huggingface.co/<repo>/resolve/main/<file>` with HEAD-based
  skip-if-already-complete and atomic `.partial` rename.
- `internal/daemon`: new `GET /hf/gguf-variants?model=…` endpoint.
  `DeployRequest` carries `gguf_variant` + `gguf_files`; the aggregator
  injects the daemon's HF token into the agent payload so gated repos
  work without the agent needing a token of its own.
- `internal/agent/gguf.go`: `ensureGGUFFiles` downloads every shard to
  `/var/lib/yokai/models/<sanitized_repo>/` before `docker run`, mounts
  `/models` into the container, and returns the primary shard's
  container path. When a GGUF variant is deployed, vLLM also gets
  `--tokenizer <repo>` injected so it can still resolve a tokenizer
  while loading from a local GGUF file.
- `config.Service` now records the chosen variant and file list.

## UI (`ui/tui`)

- New "Variant" step between Model and Config listing each quant with
  size, shard count, and the primary shard's filename.
- Selecting a variant writes the full file list into the deploy form;
  `s` skips selection when a user wants to bypass pre-download.
- Summary panel shows `Variant: Q4_K_M (3 shards)`.
- `DeployRequest` carries `gguf_variant` + `gguf_files` through to the
  daemon.

## Test plan

- [x] `go test ./internal/hf/... ./internal/daemon/... ./internal/config/...` — pass
- [x] `go build ./...` — pass
- [x] `go vet ./...` — pass
- [x] `bun test` in `ui/tui` — 23 pass, 0 fail
- [x] `bun build src/index.tsx --outdir=… --target=bun` — clean
- [ ] Manual end-to-end: deploy `unsloth/Qwen3-27B-GGUF` (llama.cpp) and
      a sharded variant; confirm every `*-of-*.gguf` shard lands in
      `/var/lib/yokai/models/<repo>/` and the container starts against
      `/models/<repo>/<primary>.gguf`.
- [ ] Manual end-to-end: deploy the same GGUF repo on vLLM; confirm
      `--tokenizer <repo>` is injected and the server boots.
- [ ] Exercise the "no GGUF files in repo" path to confirm the Variant
      step can be skipped without blocking deploy.

Note: the pre-existing `TestContainersEndpoint` in `internal/agent`
still fails without a running Docker daemon — same behavior as on
`main`; unrelated to this change.

https://claude.ai/code/session_018ibTT1n1yiPX5mqSSnKUVV

---
_Generated by [Claude Code](https://claude.ai/code/session_018ibTT1n1yiPX5mqSSnKUVV)_