### PR TITLE
fix(deploy): always land on the Variant step so GGUF quants are pickable

### DIFF
--- a/ui/tui/src/features/deploy/useDeployController.ts
+++ b/ui/tui/src/features/deploy/useDeployController.ts
@@ -184,33 +184,40 @@ export function useDeployController(active: boolean, onComplete: () => void) {
     if (form.workload === "comfyui") {
       setGGUFVariants([])
       setGGUFError(undefined)
+      setGGUFLoading(false)
       return
     }
     const model = form.model.trim()
     if (model === "") {
       setGGUFVariants([])
       setGGUFError(undefined)
+      setGGUFLoading(false)
       return
     }
 
+    // Debounce so rapid typing on the Model step doesn't hammer the Hub
+    // API. Matches the 250ms debounce used by the model-search effect.
     let cancelled = false
     setGGUFLoading(true)
     setGGUFError(undefined)
-    void getGGUFVariants(model)
-      .then((variants) => {
-        if (cancelled) return
-        setGGUFVariants(variants)
-        setGGUFLoading(false)
-      })
-      .catch((cause) => {
-        if (cancelled) return
-        setGGUFVariants([])
-        setGGUFError(cause instanceof Error ? cause.message : "failed to fetch GGUF variants")
-        setGGUFLoading(false)
-      })
+    const timeout = setTimeout(() => {
+      void getGGUFVariants(model)
+        .then((variants) => {
+          if (cancelled) return
+          setGGUFVariants(variants)
+          setGGUFLoading(false)
+        })
+        .catch((cause) => {
+          if (cancelled) return
+          setGGUFVariants([])
+          setGGUFError(cause instanceof Error ? cause.message : "failed to fetch GGUF variants")
+          setGGUFLoading(false)
+        })
+    }, 250)
 
     return () => {
       cancelled = true
+      clearTimeout(timeout)
     }
   }, [active, form.model, form.workload])
 
@@ -230,22 +237,30 @@ export function useDeployController(active: boolean, onComplete: () => void) {
     secondary: device.host,
   })), [devices])
 
+  function goToVariantStep() {
+    // Prime the loading flag so the Variant step shows a spinner on its very
+    // first frame instead of briefly flashing the "no GGUF files" empty
+    // state. The fetch effect (watching form.model) will take over as soon
+    // as it fires and either populate variants or clear the flag.
+    if (form.model.trim() !== "") {
+      setGGUFLoading(true)
+    }
+    setStep("variant")
+    setCursor(0)
+  }
+
   function advanceFromModel() {
     if (form.workload === "comfyui") {
       setStep("config")
       setCursor(0)
       return
     }
-    // Go to variant step when variants are known and non-empty, or when a
-    // request is still in flight so the user sees the spinner. If the repo
-    // has no GGUF files, skip the step entirely.
-    if (ggufLoading || ggufVariants.length > 0) {
-      setStep("variant")
-      setCursor(0)
-      return
-    }
-    setStep("config")
-    setCursor(0)
+    // Always route GGUF-capable workloads through the Variant step. The step
+    // renders a spinner while variants are being fetched and falls back to
+    // an explicit "no GGUF files in this repo, press Enter to continue"
+    // message when the repo has none — so the user always sees the variant
+    // mapping when one exists, rather than being silently skipped past.
+    goToVariantStep()
   }
 
   function selectVariantByIndex(index: number) {
@@ -333,14 +348,14 @@ export function useDeployController(active: boolean, onComplete: () => void) {
       setForm((current) => ({ ...current, model: modelId, ggufVariant: "", ggufFiles: [] }))
       setSearchError(undefined)
       setModelResults([])
-      // Defer the step advance to the next render so the new model has a
-      // chance to kick off the variants fetch; the flow tries to route via
-      // the variant step when any variants exist.
       if (form.workload === "comfyui") {
         setStep("config")
         setCursor(0)
         return
       }
+      // Prime the Variant step with a spinner on first frame so the user
+      // doesn't see an empty-state flash before the fetch effect fires.
+      setGGUFLoading(true)
       setStep("variant")
       setCursor(0)
     },


### PR DESCRIPTION
## Summary

Fixes a regression introduced with the Variant step in PR #63: on the Model step, typing a model id and hitting Enter would silently skip the Variant step and go straight to Config, so for GGUF repos the quant picker never appeared.

### Root cause

`advanceFromModel()` guarded the route to the Variant step with `if (ggufLoading || ggufVariants.length > 0)`, but those values were read from a stale React closure. When the user typed a model id and hit Enter, the variants fetch effect hadn't fired yet (effects run after render), so both were still `false`/`[]` and the handler routed to Config.

### Fix

- `advanceFromModel` now unconditionally routes non-comfyui workloads to the Variant step via a new `goToVariantStep()` helper. The Variant step itself is responsible for showing a spinner, the variant list, or the "no GGUF files in this repo, press Enter to continue" fallback — not the caller.
- `goToVariantStep()` primes `ggufLoading=true` synchronously so the step renders a spinner on its first frame instead of briefly flashing the empty-state message while the fetch is in flight.
- `selectModel` (mouse click on a search result) does the same.
- The variants fetch effect is now debounced by 250ms, matching the existing model-search effect, so typing `unsloth/Qwen3-30B-GGUF` doesn't fire ~20 requests.
- When the workload is comfyui or the model field is empty, the effect also clears `ggufLoading` (and the empty arrays/errors as before), so state can't stick if the user backs out.

## Test plan

- [x] `bun test` — 23 pass, 0 fail
- [x] `bun build src/index.tsx --outdir=… --target=bun` — clean bundle
- [ ] Manual: type `unsloth/Qwen3-30B-GGUF` into the Model field, press Enter → Variant step appears with the quant list.
- [ ] Manual: click a search result in Model step → Variant step appears with the quant list, no empty-state flash.
- [ ] Manual: type a non-GGUF repo (e.g. `meta-llama/Llama-3.1-8B-Instruct`) → Variant step appears, shows "No GGUF files in this repo, press Enter to continue", Enter advances to Config.
- [ ] Manual: switch workload to comfyui → Variant step is skipped as before.

https://claude.ai/code/session_018ibTT1n1yiPX5mqSSnKUVV

---
_Generated by [Claude Code](https://claude.ai/code/session_018ibTT1n1yiPX5mqSSnKUVV)_