### PR TITLE
fix(monitoring): average grafana stats over selected range

### DIFF
--- a/assets/grafana/dashboards/gpu-dashboard.json
+++ b/assets/grafana/dashboards/gpu-dashboard.json
@@ -8,11 +8,12 @@
   "panels": [
     {
       "id": 1,
-      "title": "Decode Tok/s",
+      "title": "Active Avg Decode Tok/s",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(yokai_llm_decode_tokens_per_second) or sum(irate(yokai_llm_generated_tokens_total[1m]))",
+          "expr": "sum(avg_over_time((yokai_llm_decode_tokens_per_second > 0)[$__range:])) or sum(avg_over_time((irate(yokai_llm_generated_tokens_total[1m]) > 0)[$__range:])) or vector(0)",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -38,11 +39,12 @@
     },
     {
       "id": 2,
-      "title": "Prefill Tok/s",
+      "title": "Active Avg Prefill Tok/s",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(yokai_llm_prefill_tokens_per_second) or sum(irate(yokai_llm_prompt_tokens_total[1m]))",
+          "expr": "sum(avg_over_time((yokai_llm_prefill_tokens_per_second > 0)[$__range:])) or sum(avg_over_time((irate(yokai_llm_prompt_tokens_total[1m]) > 0)[$__range:])) or vector(0)",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -68,11 +70,12 @@
     },
     {
       "id": 3,
-      "title": "Current Sessions",
+      "title": "Avg Nonzero Sessions",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(yokai_llm_requests_in_flight)",
+          "expr": "sum(avg_over_time((yokai_llm_requests_in_flight > 0)[$__range:])) or vector(0)",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -93,11 +96,12 @@
     },
     {
       "id": 4,
-      "title": "Queue Depth",
+      "title": "Avg Nonzero Queue",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(yokai_llm_requests_queued)",
+          "expr": "sum(avg_over_time((yokai_llm_requests_queued > 0)[$__range:])) or vector(0)",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -118,11 +122,12 @@
     },
     {
       "id": 5,
-      "title": "Generated Tokens (1h)",
+      "title": "Active Avg Generated Tok/s",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(increase(yokai_llm_generated_tokens_total[1h]))",
+          "expr": "sum(avg_over_time((irate(yokai_llm_generated_tokens_total[1m]) > 0)[$__range:])) or vector(0)",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -132,7 +137,7 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "suffix: tok/s"
         }
       },
       "gridPos": {
@@ -148,11 +153,12 @@
     },
     {
       "id": 6,
-      "title": "Services Up",
+      "title": "Avg Services Up",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(yokai_service_up)",
+          "expr": "sum(avg_over_time(yokai_service_up[$__range]))",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -173,11 +179,12 @@
     },
     {
       "id": 22,
-      "title": "Total Generated Tokens",
+      "title": "Active Avg Prompt Tok/s",
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(yokai_llm_generated_tokens_total)",
+          "expr": "sum(avg_over_time((irate(yokai_llm_prompt_tokens_total[1m]) > 0)[$__range:])) or vector(0)",
+          "instant": true,
           "refId": "A",
           "datasource": {
             "type": "prometheus",
@@ -187,7 +194,7 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "unit": "short"
+          "unit": "suffix: tok/s"
         }
       },
       "gridPos": {
@@ -672,5 +679,5 @@
   "timezone": "browser",
   "title": "Yokai LLM Monitoring",
   "uid": "yokai-monitoring",
-  "version": 8
+  "version": 10
 }

--- a/assets/monitoring_test.go
+++ b/assets/monitoring_test.go
@@ -24,11 +24,163 @@ func TestGrafanaDatasourceProvisioningReplacesStalePrometheus(t *testing.T) {
 	}
 }
 
-func TestDefaultGrafanaDashboardIncludesTotalGeneratedTokens(t *testing.T) {
+func TestDefaultGrafanaDashboardUsesSelectedRangeForStatTiles(t *testing.T) {
 	t.Parallel()
 
 	var dashboard struct {
 		Panels []struct {
+			Type    string `json:"type"`
+			Title   string `json:"title"`
+			Targets []struct {
+				Expr    string `json:"expr"`
+				Instant bool   `json:"instant"`
+			} `json:"targets"`
+		} `json:"panels"`
+	}
+	if err := json.Unmarshal([]byte(DefaultGrafanaDashboard), &dashboard); err != nil {
+		t.Fatalf("dashboard JSON should be valid: %v", err)
+	}
+
+	rangeDrivenStatPanels := map[string]bool{
+		"Active Avg Decode Tok/s":    false,
+		"Active Avg Prefill Tok/s":   false,
+		"Avg Nonzero Sessions":       false,
+		"Avg Nonzero Queue":          false,
+		"Active Avg Generated Tok/s": false,
+		"Avg Services Up":            false,
+		"Active Avg Prompt Tok/s":    false,
+	}
+
+	for _, panel := range dashboard.Panels {
+		if panel.Type != "stat" {
+			continue
+		}
+		if len(panel.Targets) == 0 {
+			t.Fatalf("stat panel %q should have a target", panel.Title)
+		}
+		expr := panel.Targets[0].Expr
+		if strings.Contains(panel.Title, "1h") || strings.Contains(expr, "[1h]") {
+			t.Fatalf("stat panel %q should not hard-code a 1h range: %s", panel.Title, expr)
+		}
+		if _, ok := rangeDrivenStatPanels[panel.Title]; !ok {
+			continue
+		}
+		if !strings.Contains(expr, "$__range") {
+			t.Fatalf("stat panel %q should use Grafana's selected range: %s", panel.Title, expr)
+		}
+		if !panel.Targets[0].Instant {
+			t.Fatalf("stat panel %q should query one selected-range value instead of a graph series", panel.Title)
+		}
+		rangeDrivenStatPanels[panel.Title] = true
+	}
+
+	for title, seen := range rangeDrivenStatPanels {
+		if !seen {
+			t.Fatalf("dashboard should include range-driven stat panel %q", title)
+		}
+	}
+}
+
+func TestDefaultGrafanaDashboardStatTilesAverageSelectedRange(t *testing.T) {
+	t.Parallel()
+
+	var dashboard struct {
+		Panels []struct {
+			Type    string `json:"type"`
+			Title   string `json:"title"`
+			Targets []struct {
+				Expr string `json:"expr"`
+			} `json:"targets"`
+		} `json:"panels"`
+	}
+	if err := json.Unmarshal([]byte(DefaultGrafanaDashboard), &dashboard); err != nil {
+		t.Fatalf("dashboard JSON should be valid: %v", err)
+	}
+
+	averagedPanels := map[string]bool{
+		"Active Avg Decode Tok/s":    false,
+		"Active Avg Prefill Tok/s":   false,
+		"Avg Nonzero Sessions":       false,
+		"Avg Nonzero Queue":          false,
+		"Active Avg Generated Tok/s": false,
+		"Avg Services Up":            false,
+		"Active Avg Prompt Tok/s":    false,
+	}
+	for _, panel := range dashboard.Panels {
+		if _, ok := averagedPanels[panel.Title]; !ok || panel.Type != "stat" {
+			continue
+		}
+		if len(panel.Targets) == 0 {
+			t.Fatalf("stat panel %q should have a target", panel.Title)
+		}
+		expr := panel.Targets[0].Expr
+		if !strings.Contains(expr, "avg_over_time(") {
+			t.Fatalf("stat panel %q should average over Grafana's selected range: %s", panel.Title, expr)
+		}
+		averagedPanels[panel.Title] = true
+	}
+	for title, seen := range averagedPanels {
+		if !seen {
+			t.Fatalf("dashboard should include averaged stat panel %q", title)
+		}
+	}
+}
+
+func TestDefaultGrafanaDashboardWorkloadStatTilesIgnoreZeroSamples(t *testing.T) {
+	t.Parallel()
+
+	var dashboard struct {
+		Panels []struct {
+			Type    string `json:"type"`
+			Title   string `json:"title"`
+			Targets []struct {
+				Expr string `json:"expr"`
+			} `json:"targets"`
+		} `json:"panels"`
+	}
+	if err := json.Unmarshal([]byte(DefaultGrafanaDashboard), &dashboard); err != nil {
+		t.Fatalf("dashboard JSON should be valid: %v", err)
+	}
+
+	nonzeroPanels := map[string]bool{
+		"Active Avg Decode Tok/s":    false,
+		"Active Avg Prefill Tok/s":   false,
+		"Avg Nonzero Sessions":       false,
+		"Avg Nonzero Queue":          false,
+		"Active Avg Generated Tok/s": false,
+		"Active Avg Prompt Tok/s":    false,
+	}
+
+	for _, panel := range dashboard.Panels {
+		if _, ok := nonzeroPanels[panel.Title]; !ok || panel.Type != "stat" {
+			continue
+		}
+		if len(panel.Targets) == 0 {
+			t.Fatalf("stat panel %q should have a target", panel.Title)
+		}
+		expr := panel.Targets[0].Expr
+		if !strings.Contains(expr, " > 0)") {
+			t.Fatalf("stat panel %q should ignore zero samples: %s", panel.Title, expr)
+		}
+		if !strings.Contains(expr, "or vector(0)") {
+			t.Fatalf("stat panel %q should return zero for fully idle ranges: %s", panel.Title, expr)
+		}
+		nonzeroPanels[panel.Title] = true
+	}
+
+	for title, seen := range nonzeroPanels {
+		if !seen {
+			t.Fatalf("dashboard should include nonzero-filtered stat panel %q", title)
+		}
+	}
+}
+
+func TestDefaultGrafanaDashboardServicesUpStatTileIncludesZeroSamples(t *testing.T) {
+	t.Parallel()
+
+	var dashboard struct {
+		Panels []struct {
+			Type    string `json:"type"`
 			Title   string `json:"title"`
 			Targets []struct {
 				Expr string `json:"expr"`
@@ -40,13 +192,18 @@ func TestDefaultGrafanaDashboardIncludesTotalGeneratedTokens(t *testing.T) {
 	}
 
 	for _, panel := range dashboard.Panels {
-		if panel.Title != "Total Generated Tokens" || len(panel.Targets) == 0 {
+		if panel.Type != "stat" || panel.Title != "Avg Services Up" {
 			continue
 		}
-		if panel.Targets[0].Expr != "sum(yokai_llm_generated_tokens_total)" {
-			t.Fatalf("unexpected total generated tokens expr: %s", panel.Targets[0].Expr)
+		if len(panel.Targets) == 0 {
+			t.Fatal("Avg Services Up should have a target")
+		}
+		expr := panel.Targets[0].Expr
+		if strings.Contains(expr, " > 0") {
+			t.Fatalf("Avg Services Up should include zero samples so downtime is visible: %s", expr)
 		}
 		return
 	}
-	t.Fatal("dashboard should include Total Generated Tokens panel")
+
+	t.Fatal("dashboard should include Avg Services Up panel")
 }


### PR DESCRIPTION
## Summary
- Update Grafana stat tiles to use instant averages over Grafana's selected range
- Ignore zero workload samples for active averages while preserving downtime visibility for services-up
- Add dashboard asset tests for selected-range, averaging, and zero-sample behavior

## Tests
- go test ./...