### PR TITLE
Add Gemma-4 vLLM chat template flag and update catalog test

### DIFF
--- a/internal/bkc/catalog_google.go
+++ b/internal/bkc/catalog_google.go
@@ -87,6 +87,7 @@ func init() {
 				"--tool-call-parser gemma4",
 				"--reasoning-parser gemma4",
 				"--enable-auto-tool-choice",
+				"--chat-template examples/tool_chat_template_gemma4.jinja",
 				"--trust-remote-code",
 			}, " "),
 			Volumes:         hfMountDefault,
@@ -100,6 +101,7 @@ func init() {
 			Arch:            ArchBlackwell,
 			Notes: []string{
 				"NVIDIA currently documents this checkpoint as TP=1 only in vLLM.",
+				"Uses the Gemma 4 vLLM chat template so reasoning and tool calls are parsed correctly.",
 				"Allows up to 4 images per request and disables audio allocation for this text/image checkpoint.",
 				"Sets --max-num-seqs 30 with a 256K context window; full-context concurrency still depends on available KV-cache memory and image token budget.",
 			},

--- a/internal/bkc/catalog_test.go
+++ b/internal/bkc/catalog_test.go
@@ -53,6 +53,12 @@ func TestLookupFindsNvidiaGemma4NVFP4(t *testing.T) {
 	if !strings.Contains(cfg.ExtraArgs, "--tool-call-parser gemma4") {
 		t.Fatalf("expected Gemma 4 tool parser flag, got %q", cfg.ExtraArgs)
 	}
+	if !strings.Contains(cfg.ExtraArgs, "--reasoning-parser gemma4") {
+		t.Fatalf("expected Gemma 4 reasoning parser flag, got %q", cfg.ExtraArgs)
+	}
+	if !strings.Contains(cfg.ExtraArgs, "--chat-template examples/tool_chat_template_gemma4.jinja") {
+		t.Fatalf("expected Gemma 4 tool chat template flag, got %q", cfg.ExtraArgs)
+	}
 	if !strings.Contains(cfg.ExtraArgs, "--tensor-parallel-size 1") {
 		t.Fatalf("expected TP=1 flag, got %q", cfg.ExtraArgs)
 	}


### PR DESCRIPTION
### Motivation
- Ensure Gemma 4 vLLM deployments use the correct chat template so tool calls and reasoning are parsed consistently by vLLM.

### Description
- Add `--chat-template examples/tool_chat_template_gemma4.jinja` to the `ExtraArgs` for the `gemma-4-26b-a4b-nvfp4` config.
- Add a `Notes` entry clarifying that the Gemma 4 vLLM chat template is used so reasoning and tool calls are parsed correctly.
- Update `TestLookupFindsNvidiaGemma4NVFP4` to assert the presence of `--reasoning-parser gemma4` and the new `--chat-template` flag in `cfg.ExtraArgs`.

### Testing
- Ran `go test ./internal/bkc -run TestLookupFindsNvidiaGemma4NVFP4` and the test passed.
- Ran `go test ./internal/bkc` and the package tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a688375788325a9e6e1f439d31a65)