### PR TITLE
Fix cross-platform TUI sidecar packaging and upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,13 @@ jobs:
           for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
             archive=$(find dist -maxdepth 1 -type f -name "Yokai_*_${platform}.tar.gz" -print -quit)
             test -n "$archive"
-            tar -tzf "$archive" | grep -qx 'yokai'
-            tar -tzf "$archive" | grep -qx 'yokai-tui'
+            archive_contents=$(tar -tzf "$archive")
+            grep -qx 'yokai' <<< "$archive_contents"
+            grep -qx 'yokai-tui' <<< "$archive_contents"
           done
 
           windows_archive=$(find dist -maxdepth 1 -type f -name 'Yokai_*_windows_amd64.zip' -print -quit)
           test -n "$windows_archive"
-          unzip -Z1 "$windows_archive" | grep -qx 'yokai.exe'
-          unzip -Z1 "$windows_archive" | grep -qx 'yokai-tui.exe'
+          windows_contents=$(unzip -Z1 "$windows_archive")
+          grep -qx 'yokai.exe' <<< "$windows_contents"
+          grep -qx 'yokai-tui.exe' <<< "$windows_contents"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,39 @@ jobs:
       - name: Compile standalone OpenTUI
         run: bun build --compile --format=esm --minify --bytecode src/index.tsx --outfile=../../bin/yokai-tui
 
-  release-config:
+  release-package:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate GoReleaser configuration
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Build snapshot release
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: check
+          args: release --snapshot --clean
+      - name: Verify release archives contain both binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive_count=$(find dist -maxdepth 1 -type f \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')
+          test "$archive_count" -eq 5
+
+          for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64; do
+            archive=$(find dist -maxdepth 1 -type f -name "Yokai_*_${platform}.tar.gz" -print -quit)
+            test -n "$archive"
+            tar -tzf "$archive" | grep -qx 'yokai'
+            tar -tzf "$archive" | grep -qx 'yokai-tui'
+          done
+
+          windows_archive=$(find dist -maxdepth 1 -type f -name 'Yokai_*_windows_amd64.zip' -print -quit)
+          test -n "$windows_archive"
+          unzip -Z1 "$windows_archive" | grep -qx 'yokai.exe'
+          unzip -Z1 "$windows_archive" | grep -qx 'yokai-tui.exe'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,14 @@ jobs:
         run: bun run build
       - name: Compile standalone OpenTUI
         run: bun build --compile --format=esm --minify --bytecode src/index.tsx --outfile=../../bin/yokai-tui
+
+  release-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate GoReleaser configuration
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,10 @@ jobs:
       - name: Determine version bump
         id: version
         run: |
-          # Get the latest tag, default to v0.0.0 if none exists
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Select the highest release tag even if repository history was
+          # rewritten and older tags are no longer ancestors of main.
+          LATEST_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)
+          LATEST_TAG=${LATEST_TAG:-v0.0.0}
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
 
           # If this was triggered by a tag push, use that tag directly

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,12 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      # Bun cannot currently build the TUI sidecar for Windows ARM64.
+      # Do not publish a partial archive that would leave users with a
+      # stale or missing UI after installation.
+      - goos: windows
+        goarch: arm64
     ldflags:
       # Strip debug info and inject version/build time
       - -s -w -X main.version={{.Version}} -X main.buildTime={{.Date}}
@@ -29,11 +35,11 @@ builds:
     dir: ui/tui
     main: src/index.tsx
     targets:
-      - bun-linux-x64
-      - bun-linux-arm64
-      - bun-darwin-x64
-      - bun-darwin-arm64
-      - bun-windows-x64
+      - linux-x64-modern
+      - linux-arm64
+      - darwin-x64
+      - darwin-arm64
+      - windows-x64-modern
     flags:
       - --compile
       - --format=esm
@@ -43,7 +49,6 @@ builds:
 archives:
   - formats:
       - tar.gz
-    allow_different_binary_count: true
     ids:
       - yokai
       - yokai-tui

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ FALLBACK_INSTALL_DIR="$HOME/.local/bin"
 BINARY="yokai"
 TUI_BINARY="yokai-tui"
 PROJECT_NAME="Yokai"
+EXISTING_YOKAI=$(command -v "$BINARY" 2>/dev/null || true)
 
 # Colors
 RED='\033[0;31m'
@@ -95,12 +96,22 @@ TUI_SRC=$(find "$TMP_DIR" -name "$TUI_BINARY" -type f | head -n 1)
 if [ -z "$YOKAI_SRC" ]; then
   fail "Could not find '${BINARY}' in the downloaded archive."
 fi
+if [ -z "$TUI_SRC" ]; then
+  fail "Could not find '${TUI_BINARY}' in the downloaded archive. Refusing to leave an old UI sidecar installed."
+fi
 
 # ── Install ──────────────────────────────────────────────────────
 step "Installing"
 
 USE_SUDO=0
-if [ -w "$INSTALL_DIR" ]; then
+if [ -n "$EXISTING_YOKAI" ] && [ -f "$EXISTING_YOKAI" ] && [ -w "$(dirname "$EXISTING_YOKAI")" ]; then
+  TARGET_DIR=$(dirname "$EXISTING_YOKAI")
+elif [ -n "$EXISTING_YOKAI" ] && [ -f "$EXISTING_YOKAI" ] && command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  TARGET_DIR=$(dirname "$EXISTING_YOKAI")
+  USE_SUDO=1
+elif [ -n "$EXISTING_YOKAI" ] && [ -f "$EXISTING_YOKAI" ]; then
+  fail "Existing installation at '${EXISTING_YOKAI}' is not writable. Run 'sudo -v' and rerun the installer so the active installation can be replaced."
+elif [ -w "$INSTALL_DIR" ]; then
   TARGET_DIR="$INSTALL_DIR"
 elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
   TARGET_DIR="$INSTALL_DIR"
@@ -126,9 +137,7 @@ if [ "$TARGET_DIR" = "$FALLBACK_INSTALL_DIR" ]; then
 fi
 
 install_bin "$YOKAI_SRC" "${TARGET_DIR}/${BINARY}"
-if [ -n "$TUI_SRC" ]; then
-  install_bin "$TUI_SRC" "${TARGET_DIR}/${TUI_BINARY}"
-fi
+install_bin "$TUI_SRC" "${TARGET_DIR}/${TUI_BINARY}"
 
 if [ "$TARGET_DIR" = "$FALLBACK_INSTALL_DIR" ]; then
   # Add to PATH in shell rc files

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -141,12 +141,14 @@ func Run(currentVersion string) error {
 		return fmt.Errorf("failed to extract archive: %w", err)
 	}
 
-	// Find the yokai binary in extracted files
-	newBinaryPath := filepath.Join(tempDir, "yokai")
-	if _, err := os.Stat(newBinaryPath); os.IsNotExist(err) {
-		return fmt.Errorf("yokai binary not found in archive")
+	newBinaryPath, err := findExtractedBinary(tempDir, "yokai")
+	if err != nil {
+		return err
 	}
-	newTUIBinaryPath := filepath.Join(tempDir, companionBinaryName())
+	newTUIBinaryPath, err := findExtractedBinary(tempDir, companionBinaryName())
+	if err != nil {
+		return err
+	}
 
 	// 5. Replace current binary
 	currentBinaryPath, err := os.Executable()
@@ -170,13 +172,9 @@ func Run(currentVersion string) error {
 		return fmt.Errorf("failed to backup current binary: %w", err)
 	}
 	oldTUIBinaryPath := currentTUIBinaryPath + ".old"
-	hasNewTUIBinary := false
-	if _, err := os.Stat(newTUIBinaryPath); err == nil {
-		hasNewTUIBinary = true
-		if err := backupCompanionBinary(currentTUIBinaryPath, oldTUIBinaryPath); err != nil {
-			_ = os.Rename(oldBinaryPath, currentBinaryPath)
-			return err
-		}
+	if err := backupCompanionBinary(currentTUIBinaryPath, oldTUIBinaryPath); err != nil {
+		_ = os.Rename(oldBinaryPath, currentBinaryPath)
+		return err
 	}
 
 	// Move new binary to current path
@@ -185,30 +183,24 @@ func Run(currentVersion string) error {
 		_ = os.Rename(oldBinaryPath, currentBinaryPath) // Best-effort rollback to previous binary.
 		return fmt.Errorf("failed to install new binary: %w", err)
 	}
-	if hasNewTUIBinary {
-		if err := os.Rename(newTUIBinaryPath, currentTUIBinaryPath); err != nil {
-			_ = os.Remove(currentBinaryPath)
-			_ = os.Rename(oldBinaryPath, currentBinaryPath)
-			_ = restoreCompanionBinary(currentTUIBinaryPath, oldTUIBinaryPath)
-			return fmt.Errorf("failed to install yokai-tui binary: %w", err)
-		}
+	if err := os.Rename(newTUIBinaryPath, currentTUIBinaryPath); err != nil {
+		_ = os.Remove(currentBinaryPath)
+		_ = os.Rename(oldBinaryPath, currentBinaryPath)
+		_ = restoreCompanionBinary(currentTUIBinaryPath, oldTUIBinaryPath)
+		return fmt.Errorf("failed to install yokai-tui binary: %w", err)
 	}
 
 	// Make it executable
 	if err := platform.ChmodIfSupported(currentBinaryPath, 0755); err != nil {
 		return fmt.Errorf("failed to make binary executable: %w", err)
 	}
-	if hasNewTUIBinary {
-		if err := platform.ChmodIfSupported(currentTUIBinaryPath, 0755); err != nil {
-			return fmt.Errorf("failed to make yokai-tui executable: %w", err)
-		}
+	if err := platform.ChmodIfSupported(currentTUIBinaryPath, 0755); err != nil {
+		return fmt.Errorf("failed to make yokai-tui executable: %w", err)
 	}
 
 	// Remove .old
 	_ = os.Remove(oldBinaryPath) // Best-effort cleanup of backup binary.
-	if hasNewTUIBinary {
-		_ = os.Remove(oldTUIBinaryPath)
-	}
+	_ = os.Remove(oldTUIBinaryPath)
 
 	// 6. Print success message
 	fmt.Printf("✅ Successfully updated to %s!\n", release.TagName)
@@ -222,6 +214,34 @@ func companionBinaryName() string {
 		return tuiBinary + ".exe"
 	}
 	return tuiBinary
+}
+
+func findExtractedBinary(root, name string) (string, error) {
+	var found string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || entry.Name() != name {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		found = path
+		return filepath.SkipAll
+	})
+	if err != nil {
+		return "", fmt.Errorf("finding %s in archive: %w", name, err)
+	}
+	if found == "" {
+		return "", fmt.Errorf("%s binary not found in archive", name)
+	}
+	return found, nil
 }
 
 func backupCompanionBinary(currentPath, backupPath string) error {

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -111,7 +112,7 @@ func Run(currentVersion string) error {
 	}
 
 	// Create temp file
-	tempFile, err := os.CreateTemp("", "yokai-update-*.tar.gz")
+	tempFile, err := os.CreateTemp("", updateArchivePattern(archiveExt))
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
@@ -128,7 +129,7 @@ func Run(currentVersion string) error {
 		return fmt.Errorf("failed to save download: %w", err)
 	}
 
-	// 4. Extract tar.gz
+	// 4. Extract the downloaded release archive.
 	tempDir, err := os.MkdirTemp("", "yokai-extract-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp directory: %w", err)
@@ -163,44 +164,9 @@ func Run(currentVersion string) error {
 	}
 
 	fmt.Println("Installing update...")
-	currentDir := filepath.Dir(currentBinaryPath)
-	currentTUIBinaryPath := filepath.Join(currentDir, companionBinaryName())
-
-	// Rename current binary to .old
-	oldBinaryPath := currentBinaryPath + ".old"
-	if err := os.Rename(currentBinaryPath, oldBinaryPath); err != nil {
-		return fmt.Errorf("failed to backup current binary: %w", err)
-	}
-	oldTUIBinaryPath := currentTUIBinaryPath + ".old"
-	if err := backupCompanionBinary(currentTUIBinaryPath, oldTUIBinaryPath); err != nil {
-		_ = os.Rename(oldBinaryPath, currentBinaryPath)
+	if err := installUpdatePair(newBinaryPath, newTUIBinaryPath, currentBinaryPath); err != nil {
 		return err
 	}
-
-	// Move new binary to current path
-	if err := os.Rename(newBinaryPath, currentBinaryPath); err != nil {
-		// Try to restore old binary
-		_ = os.Rename(oldBinaryPath, currentBinaryPath) // Best-effort rollback to previous binary.
-		return fmt.Errorf("failed to install new binary: %w", err)
-	}
-	if err := os.Rename(newTUIBinaryPath, currentTUIBinaryPath); err != nil {
-		_ = os.Remove(currentBinaryPath)
-		_ = os.Rename(oldBinaryPath, currentBinaryPath)
-		_ = restoreCompanionBinary(currentTUIBinaryPath, oldTUIBinaryPath)
-		return fmt.Errorf("failed to install yokai-tui binary: %w", err)
-	}
-
-	// Make it executable
-	if err := platform.ChmodIfSupported(currentBinaryPath, 0755); err != nil {
-		return fmt.Errorf("failed to make binary executable: %w", err)
-	}
-	if err := platform.ChmodIfSupported(currentTUIBinaryPath, 0755); err != nil {
-		return fmt.Errorf("failed to make yokai-tui executable: %w", err)
-	}
-
-	// Remove .old
-	_ = os.Remove(oldBinaryPath) // Best-effort cleanup of backup binary.
-	_ = os.Remove(oldTUIBinaryPath)
 
 	// 6. Print success message
 	fmt.Printf("✅ Successfully updated to %s!\n", release.TagName)
@@ -214,6 +180,10 @@ func companionBinaryName() string {
 		return tuiBinary + ".exe"
 	}
 	return tuiBinary
+}
+
+func updateArchivePattern(archiveExt string) string {
+	return "yokai-update-*" + archiveExt
 }
 
 func findExtractedBinary(root, name string) (string, error) {
@@ -244,24 +214,174 @@ func findExtractedBinary(root, name string) (string, error) {
 	return found, nil
 }
 
-func backupCompanionBinary(currentPath, backupPath string) error {
-	if err := os.Rename(currentPath, backupPath); err != nil {
+type updateFileOps struct {
+	rename func(string, string) error
+	chmod  func(string, os.FileMode) error
+}
+
+var defaultUpdateFileOps = updateFileOps{
+	rename: os.Rename,
+	chmod:  platform.ChmodIfSupported,
+}
+
+func installUpdatePair(newBinaryPath, newTUIBinaryPath, currentBinaryPath string) error {
+	return installUpdatePairWithOps(newBinaryPath, newTUIBinaryPath, currentBinaryPath, defaultUpdateFileOps)
+}
+
+func installUpdatePairWithOps(
+	newBinaryPath, newTUIBinaryPath, currentBinaryPath string,
+	ops updateFileOps,
+) error {
+	currentDir := filepath.Dir(currentBinaryPath)
+	currentTUIBinaryPath := filepath.Join(currentDir, companionBinaryName())
+
+	// Stage both files beside the active installation. This avoids cross-device
+	// rename failures after the old pair has already been moved out of the way.
+	stagedBinaryPath, err := stageUpdateBinary(newBinaryPath, currentDir, ".yokai-update-*", ops)
+	if err != nil {
+		return fmt.Errorf("staging yokai binary: %w", err)
+	}
+	defer func() { _ = os.Remove(stagedBinaryPath) }()
+
+	stagedTUIBinaryPath, err := stageUpdateBinary(newTUIBinaryPath, currentDir, ".yokai-tui-update-*", ops)
+	if err != nil {
+		return fmt.Errorf("staging yokai-tui binary: %w", err)
+	}
+	defer func() { _ = os.Remove(stagedTUIBinaryPath) }()
+
+	oldBinaryPath, err := availableBackupPath(currentBinaryPath)
+	if err != nil {
+		return fmt.Errorf("reserving yokai backup path: %w", err)
+	}
+	oldTUIBinaryPath, err := availableBackupPath(currentTUIBinaryPath)
+	if err != nil {
+		return fmt.Errorf("reserving yokai-tui backup path: %w", err)
+	}
+
+	if err := ops.rename(currentBinaryPath, oldBinaryPath); err != nil {
+		return fmt.Errorf("backing up current binary: %w", err)
+	}
+
+	hadOldTUI := true
+	if err := ops.rename(currentTUIBinaryPath, oldTUIBinaryPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			hadOldTUI = false
+		} else {
+			cause := fmt.Errorf("backing up yokai-tui binary: %w", err)
+			return withRollback(cause, ops.rename(oldBinaryPath, currentBinaryPath))
 		}
-		return fmt.Errorf("failed to backup yokai-tui binary: %w", err)
+	}
+
+	if err := ops.rename(stagedBinaryPath, currentBinaryPath); err != nil {
+		cause := fmt.Errorf("installing yokai binary: %w", err)
+		return withRollback(cause, rollbackUpdatePair(
+			currentBinaryPath, currentTUIBinaryPath,
+			oldBinaryPath, oldTUIBinaryPath,
+			hadOldTUI, ops,
+		))
+	}
+	if err := ops.rename(stagedTUIBinaryPath, currentTUIBinaryPath); err != nil {
+		cause := fmt.Errorf("installing yokai-tui binary: %w", err)
+		return withRollback(cause, rollbackUpdatePair(
+			currentBinaryPath, currentTUIBinaryPath,
+			oldBinaryPath, oldTUIBinaryPath,
+			hadOldTUI, ops,
+		))
+	}
+
+	_ = os.Remove(oldBinaryPath)
+	if hadOldTUI {
+		_ = os.Remove(oldTUIBinaryPath)
 	}
 	return nil
 }
 
-func restoreCompanionBinary(currentPath, backupPath string) error {
-	if err := os.Rename(backupPath, currentPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
+func stageUpdateBinary(sourcePath, targetDir, pattern string, ops updateFileOps) (string, error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = source.Close() }()
+
+	staged, err := os.CreateTemp(targetDir, pattern)
+	if err != nil {
+		return "", err
+	}
+	stagedPath := staged.Name()
+	keep := false
+	defer func() {
+		_ = staged.Close()
+		if !keep {
+			_ = os.Remove(stagedPath)
 		}
+	}()
+
+	if _, err := io.Copy(staged, source); err != nil {
+		return "", err
+	}
+	if err := staged.Close(); err != nil {
+		return "", err
+	}
+	if err := ops.chmod(stagedPath, 0755); err != nil {
+		return "", err
+	}
+
+	keep = true
+	return stagedPath, nil
+}
+
+func availableBackupPath(targetPath string) (string, error) {
+	placeholder, err := os.CreateTemp(filepath.Dir(targetPath), "."+filepath.Base(targetPath)+".old-*")
+	if err != nil {
+		return "", err
+	}
+	path := placeholder.Name()
+	if err := placeholder.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := os.Remove(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func rollbackUpdatePair(
+	currentBinaryPath, currentTUIBinaryPath string,
+	oldBinaryPath, oldTUIBinaryPath string,
+	hadOldTUI bool,
+	ops updateFileOps,
+) error {
+	var rollbackErrors []error
+	if err := removeIfExists(currentBinaryPath); err != nil {
+		rollbackErrors = append(rollbackErrors, fmt.Errorf("removing new yokai binary: %w", err))
+	}
+	if err := removeIfExists(currentTUIBinaryPath); err != nil {
+		rollbackErrors = append(rollbackErrors, fmt.Errorf("removing new yokai-tui binary: %w", err))
+	}
+	if err := ops.rename(oldBinaryPath, currentBinaryPath); err != nil {
+		rollbackErrors = append(rollbackErrors, fmt.Errorf("restoring yokai binary: %w", err))
+	}
+	if hadOldTUI {
+		if err := ops.rename(oldTUIBinaryPath, currentTUIBinaryPath); err != nil {
+			rollbackErrors = append(rollbackErrors, fmt.Errorf("restoring yokai-tui binary: %w", err))
+		}
+	}
+	return errors.Join(rollbackErrors...)
+}
+
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
+}
+
+func withRollback(cause, rollbackErr error) error {
+	if rollbackErr == nil {
+		return cause
+	}
+	return errors.Join(cause, fmt.Errorf("rollback failed: %w", rollbackErr))
 }
 
 // extractArchive extracts a release archive to the specified directory.

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -20,6 +20,7 @@ const (
 	latestReleaseURL = "https://github.com/spencerbull/yokai/releases/latest"
 	repoBaseURL      = "https://github.com/spencerbull/yokai/releases/download"
 	projectName      = "Yokai"
+	mainBinary       = "yokai"
 	tuiBinary        = "yokai-tui"
 )
 
@@ -142,7 +143,7 @@ func Run(currentVersion string) error {
 		return fmt.Errorf("failed to extract archive: %w", err)
 	}
 
-	newBinaryPath, err := findExtractedBinary(tempDir, "yokai")
+	newBinaryPath, err := findExtractedBinary(tempDir, mainBinaryName())
 	if err != nil {
 		return err
 	}
@@ -176,10 +177,18 @@ func Run(currentVersion string) error {
 }
 
 func companionBinaryName() string {
-	if runtime.GOOS == "windows" {
-		return tuiBinary + ".exe"
+	return binaryNameForOS(tuiBinary, runtime.GOOS)
+}
+
+func mainBinaryName() string {
+	return binaryNameForOS(mainBinary, runtime.GOOS)
+}
+
+func binaryNameForOS(name, goos string) string {
+	if goos == "windows" {
+		return name + ".exe"
 	}
-	return tuiBinary
+	return name
 }
 
 func updateArchivePattern(archiveExt string) string {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,10 +1,50 @@
 package upgrade
 
 import (
+	"archive/zip"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestUpdateArchivePatternPreservesFormat(t *testing.T) {
+	for _, ext := range []string{".tar.gz", ".zip"} {
+		if pattern := updateArchivePattern(ext); !strings.HasSuffix(pattern, ext) {
+			t.Fatalf("pattern %q does not preserve extension %q", pattern, ext)
+		}
+	}
+}
+
+func TestExtractArchiveUsesZipPath(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "update.zip")
+	archive, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+	writer := zip.NewWriter(archive)
+	entry, err := writer.Create("yokai.exe")
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := entry.Write([]byte("windows-binary")); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	destination := t.TempDir()
+	if err := extractArchive(archivePath, destination); err != nil {
+		t.Fatalf("extract zip: %v", err)
+	}
+	assertFileContents(t, filepath.Join(destination, "yokai.exe"), "windows-binary")
+}
 
 func TestFindExtractedBinaryFindsArchiveRootBinary(t *testing.T) {
 	tempDir := t.TempDir()
@@ -50,5 +90,111 @@ func TestFindExtractedBinaryRequiresRegularFile(t *testing.T) {
 
 	if _, err := findExtractedBinary(tempDir, "yokai-tui"); err == nil {
 		t.Fatal("expected missing regular file error")
+	}
+}
+
+func TestInstallUpdatePairReplacesBothBinaries(t *testing.T) {
+	installDir := t.TempDir()
+	currentBinaryPath := filepath.Join(installDir, "yokai")
+	currentTUIBinaryPath := filepath.Join(installDir, companionBinaryName())
+	writeTestFile(t, currentBinaryPath, "old-yokai")
+	writeTestFile(t, currentTUIBinaryPath, "old-tui")
+
+	newDir := t.TempDir()
+	newBinaryPath := filepath.Join(newDir, "yokai")
+	newTUIBinaryPath := filepath.Join(newDir, companionBinaryName())
+	writeTestFile(t, newBinaryPath, "new-yokai")
+	writeTestFile(t, newTUIBinaryPath, "new-tui")
+
+	if err := installUpdatePair(newBinaryPath, newTUIBinaryPath, currentBinaryPath); err != nil {
+		t.Fatalf("install update pair: %v", err)
+	}
+	assertFileContents(t, currentBinaryPath, "new-yokai")
+	assertFileContents(t, currentTUIBinaryPath, "new-tui")
+}
+
+func TestInstallUpdatePairRollsBackBothBinariesOnRenameFailure(t *testing.T) {
+	for _, failAtCall := range []int{3, 4} {
+		t.Run(fmt.Sprintf("rename_%d", failAtCall), func(t *testing.T) {
+			installDir := t.TempDir()
+			currentBinaryPath := filepath.Join(installDir, "yokai")
+			currentTUIBinaryPath := filepath.Join(installDir, companionBinaryName())
+			writeTestFile(t, currentBinaryPath, "old-yokai")
+			writeTestFile(t, currentTUIBinaryPath, "old-tui")
+
+			newDir := t.TempDir()
+			newBinaryPath := filepath.Join(newDir, "yokai")
+			newTUIBinaryPath := filepath.Join(newDir, companionBinaryName())
+			writeTestFile(t, newBinaryPath, "new-yokai")
+			writeTestFile(t, newTUIBinaryPath, "new-tui")
+
+			renameCalls := 0
+			ops := defaultUpdateFileOps
+			ops.rename = func(oldPath, newPath string) error {
+				renameCalls++
+				if renameCalls == failAtCall {
+					return errors.New("injected rename failure")
+				}
+				return os.Rename(oldPath, newPath)
+			}
+
+			if err := installUpdatePairWithOps(newBinaryPath, newTUIBinaryPath, currentBinaryPath, ops); err == nil {
+				t.Fatal("expected install failure")
+			}
+			assertFileContents(t, currentBinaryPath, "old-yokai")
+			assertFileContents(t, currentTUIBinaryPath, "old-tui")
+		})
+	}
+}
+
+func TestInstallUpdatePairLeavesActivePairUntouchedOnChmodFailure(t *testing.T) {
+	for _, failAtCall := range []int{1, 2} {
+		t.Run(fmt.Sprintf("chmod_%d", failAtCall), func(t *testing.T) {
+			installDir := t.TempDir()
+			currentBinaryPath := filepath.Join(installDir, "yokai")
+			currentTUIBinaryPath := filepath.Join(installDir, companionBinaryName())
+			writeTestFile(t, currentBinaryPath, "old-yokai")
+			writeTestFile(t, currentTUIBinaryPath, "old-tui")
+
+			newDir := t.TempDir()
+			newBinaryPath := filepath.Join(newDir, "yokai")
+			newTUIBinaryPath := filepath.Join(newDir, companionBinaryName())
+			writeTestFile(t, newBinaryPath, "new-yokai")
+			writeTestFile(t, newTUIBinaryPath, "new-tui")
+
+			chmodCalls := 0
+			ops := defaultUpdateFileOps
+			ops.chmod = func(path string, mode os.FileMode) error {
+				chmodCalls++
+				if chmodCalls == failAtCall {
+					return errors.New("injected chmod failure")
+				}
+				return os.Chmod(path, mode)
+			}
+
+			if err := installUpdatePairWithOps(newBinaryPath, newTUIBinaryPath, currentBinaryPath, ops); err == nil {
+				t.Fatal("expected staging failure")
+			}
+			assertFileContents(t, currentBinaryPath, "old-yokai")
+			assertFileContents(t, currentTUIBinaryPath, "old-tui")
+		})
+	}
+}
+
+func writeTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertFileContents(t *testing.T, path, want string) {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(contents) != want {
+		t.Fatalf("%s contains %q, want %q", path, contents, want)
 	}
 }

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -18,6 +18,26 @@ func TestUpdateArchivePatternPreservesFormat(t *testing.T) {
 	}
 }
 
+func TestBinaryNameForOS(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		want string
+	}{
+		{name: "yokai", goos: "linux", want: "yokai"},
+		{name: "yokai", goos: "darwin", want: "yokai"},
+		{name: "yokai", goos: "windows", want: "yokai.exe"},
+		{name: "yokai-tui", goos: "windows", want: "yokai-tui.exe"},
+	}
+	for _, test := range tests {
+		t.Run(test.goos+"_"+test.name, func(t *testing.T) {
+			if got := binaryNameForOS(test.name, test.goos); got != test.want {
+				t.Fatalf("binaryNameForOS(%q, %q) = %q, want %q", test.name, test.goos, got, test.want)
+			}
+		})
+	}
+}
+
 func TestExtractArchiveUsesZipPath(t *testing.T) {
 	archivePath := filepath.Join(t.TempDir(), "update.zip")
 	archive, err := os.Create(archivePath)
@@ -43,7 +63,11 @@ func TestExtractArchiveUsesZipPath(t *testing.T) {
 	if err := extractArchive(archivePath, destination); err != nil {
 		t.Fatalf("extract zip: %v", err)
 	}
-	assertFileContents(t, filepath.Join(destination, "yokai.exe"), "windows-binary")
+	extractedPath, err := findExtractedBinary(destination, binaryNameForOS(mainBinary, "windows"))
+	if err != nil {
+		t.Fatalf("find extracted Windows binary: %v", err)
+	}
+	assertFileContents(t, extractedPath, "windows-binary")
 }
 
 func TestFindExtractedBinaryFindsArchiveRootBinary(t *testing.T) {

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,0 +1,54 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindExtractedBinaryFindsArchiveRootBinary(t *testing.T) {
+	tempDir := t.TempDir()
+	binaryPath := filepath.Join(tempDir, "yokai-tui")
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	got, err := findExtractedBinary(tempDir, "yokai-tui")
+	if err != nil {
+		t.Fatalf("find binary: %v", err)
+	}
+	if got != binaryPath {
+		t.Fatalf("got %q, want %q", got, binaryPath)
+	}
+}
+
+func TestFindExtractedBinaryFindsNestedBinary(t *testing.T) {
+	tempDir := t.TempDir()
+	nestedDir := filepath.Join(tempDir, "Yokai_0.1.0_darwin_arm64")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	binaryPath := filepath.Join(nestedDir, "yokai-tui")
+	if err := os.WriteFile(binaryPath, []byte("binary"), 0755); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+
+	got, err := findExtractedBinary(tempDir, "yokai-tui")
+	if err != nil {
+		t.Fatalf("find binary: %v", err)
+	}
+	if got != binaryPath {
+		t.Fatalf("got %q, want %q", got, binaryPath)
+	}
+}
+
+func TestFindExtractedBinaryRequiresRegularFile(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tempDir, "yokai-tui"), 0755); err != nil {
+		t.Fatalf("mkdir binary-name dir: %v", err)
+	}
+
+	if _, err := findExtractedBinary(tempDir, "yokai-tui"); err == nil {
+		t.Fatal("expected missing regular file error")
+	}
+}


### PR DESCRIPTION
## What changed

- use current GoReleaser Bun target syntax and publish only platform archives that can contain both `yokai` and `yokai-tui`
- require equal binary counts in release archives and validate the GoReleaser config in CI
- update the installer in place when an active Yokai installation already exists, rather than writing a second pair elsewhere on `PATH`
- fail safely when the TUI sidecar is missing or the active install cannot be replaced
- make self-upgrade locate nested archive binaries and require/install the TUI sidecar as part of the same update
- add coverage for archive binary discovery

## Root cause

The installer could place a newly downloaded `yokai`/`yokai-tui` pair in a different directory from the active `yokai` resolved by the shell. It also treated `yokai-tui` as optional, while the release config explicitly allowed archives with different binary counts. Those behaviors could leave macOS launching an older sidecar even after a successful-looking install, while a clean Linux install launched the current OpenTUI.

## Impact

Installs and upgrades now keep the Go launcher and OpenTUI sidecar together and refuse partial updates. Release archives are complete and consistent for macOS ARM64/x64, Linux ARM64/x64, and Windows x64.

## Validation

- `make build`
- `make tui-test tui-build tui-compile`
- `go test ./internal/upgrade`
- `sh -n install.sh`
- GoReleaser v2.17 configuration check
- full GoReleaser snapshot release; verified every emitted archive contains both binaries
