### PR TITLE
feat: add encrypted Firebase device config sync

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,7 @@
+{
+  "projects": {
+    "development": "yokai-config-dev-260709-5820",
+    "staging": "yokai-config-stg-260709-5820",
+    "production": "yokai-config-260709-5820"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main]
+    branches: [develop, staging, main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,25 @@ jobs:
           windows_contents=$(unzip -Z1 "$windows_archive")
           grep -qx 'yokai.exe' <<< "$windows_contents"
           grep -qx 'yokai-tui.exe' <<< "$windows_contents"
+
+  firestore-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tests/firebase/package-lock.json
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install Firebase test dependencies
+        run: npm ci
+        working-directory: tests/firebase
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools@15.22.4
+      - name: Test Firestore security rules
+        run: npm test
+        working-directory: tests/firebase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,19 +104,21 @@ jobs:
   firestore-rules:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: npm
           cache-dependency-path: tests/firebase/package-lock.json
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
       - name: Install Firebase test dependencies
         run: npm ci
         working-directory: tests/firebase
+      - name: Test provisioning safeguards
+        run: bash tests/scripts/setup-common.test.sh
       - name: Install Firebase CLI
         run: npm install --global firebase-tools@15.22.4
       - name: Test Firestore security rules

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -2,7 +2,7 @@ name: Deploy Firebase backend
 
 on:
   push:
-    branches: [main]
+    branches: [develop, staging, main]
     paths:
       - firestore.rules
       - firebase.json
@@ -13,15 +13,31 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: firebase-production
-  cancel-in-progress: false
-
 env:
   FIREBASE_TOOLS_VERSION: 15.22.4
   FIREBASE_TOOLS_SHA256_LINUX: 9f20848be954b4c30d323d10d93311c991ae4508dbc782c4a076530cc84412c1
 
 jobs:
+  select-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.target.outputs.environment }}
+    steps:
+      - name: Map branch to deployment environment
+        id: target
+        shell: bash
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            develop) environment=firebase-development ;;
+            staging) environment=firebase-staging ;;
+            main) environment=firebase-production ;;
+            *)
+              echo "Unsupported deployment branch: ${GITHUB_REF_NAME}" >&2
+              exit 1
+              ;;
+          esac
+          echo "environment=${environment}" >> "${GITHUB_OUTPUT}"
+
   test-rules:
     runs-on: ubuntu-latest
     steps:
@@ -49,9 +65,12 @@ jobs:
         working-directory: tests/firebase
 
   deploy-rules:
-    needs: test-rules
+    needs: [select-environment, test-rules]
     runs-on: ubuntu-latest
-    environment: firebase-production
+    environment: ${{ needs.select-environment.outputs.environment }}
+    concurrency:
+      group: ${{ needs.select-environment.outputs.environment }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -69,5 +88,11 @@ jobs:
           project_id: ${{ vars.FIREBASE_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+      - name: Verify environment configuration
+        shell: bash
+        run: |
+          test -n "${{ vars.FIREBASE_PROJECT_ID }}"
+          test -n "${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}"
+          test -n "${{ vars.GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT }}"
       - name: Deploy Firestore security rules
         run: firebase deploy --only firestore:rules --project "${{ vars.FIREBASE_PROJECT_ID }}" --config firebase.json --non-interactive

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -17,25 +17,33 @@ concurrency:
   group: firebase-production
   cancel-in-progress: false
 
+env:
+  FIREBASE_TOOLS_VERSION: 15.22.4
+  FIREBASE_TOOLS_SHA256_LINUX: 9f20848be954b4c30d323d10d93311c991ae4508dbc782c4a076530cc84412c1
+
 jobs:
   test-rules:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: npm
           cache-dependency-path: tests/firebase/package-lock.json
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
       - name: Install Firebase test dependencies
         run: npm ci
         working-directory: tests/firebase
-      - name: Install Firebase CLI
-        run: npm install --global firebase-tools@15.22.4
+      - name: Install verified Firebase CLI
+        run: |
+          curl -fsSL "https://github.com/firebase/firebase-tools/releases/download/v${FIREBASE_TOOLS_VERSION}/firebase-tools-linux" -o "${RUNNER_TEMP}/firebase"
+          echo "${FIREBASE_TOOLS_SHA256_LINUX}  ${RUNNER_TEMP}/firebase" | sha256sum --check --strict
+          chmod 0755 "${RUNNER_TEMP}/firebase"
+          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
       - name: Test Firestore security rules
         run: npm test
         working-directory: tests/firebase
@@ -48,21 +56,18 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: tests/firebase/package-lock.json
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install verified Firebase CLI
+        run: |
+          curl -fsSL "https://github.com/firebase/firebase-tools/releases/download/v${FIREBASE_TOOLS_VERSION}/firebase-tools-linux" -o "${RUNNER_TEMP}/firebase"
+          echo "${FIREBASE_TOOLS_SHA256_LINUX}  ${RUNNER_TEMP}/firebase" | sha256sum --check --strict
+          chmod 0755 "${RUNNER_TEMP}/firebase"
+          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
+          project_id: ${{ vars.FIREBASE_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
-      - name: Install Firebase test dependencies
-        run: npm ci
-        working-directory: tests/firebase
-      - name: Install Firebase CLI
-        run: npm install --global firebase-tools@15.22.4
       - name: Deploy Firestore security rules
         run: firebase deploy --only firestore:rules --project "${{ vars.FIREBASE_PROJECT_ID }}" --config firebase.json --non-interactive

--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -1,0 +1,68 @@
+name: Deploy Firebase backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - firestore.rules
+      - firebase.json
+      - tests/firebase/**
+      - .github/workflows/deploy-firebase.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: firebase-production
+  cancel-in-progress: false
+
+jobs:
+  test-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tests/firebase/package-lock.json
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install Firebase test dependencies
+        run: npm ci
+        working-directory: tests/firebase
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools@15.22.4
+      - name: Test Firestore security rules
+        run: npm test
+        working-directory: tests/firebase
+
+  deploy-rules:
+    needs: test-rules
+    runs-on: ubuntu-latest
+    environment: firebase-production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tests/firebase/package-lock.json
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT }}
+      - name: Install Firebase test dependencies
+        run: npm ci
+        working-directory: tests/firebase
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools@15.22.4
+      - name: Deploy Firestore security rules
+        run: firebase deploy --only firestore:rules --project "${{ vars.FIREBASE_PROJECT_ID }}" --config firebase.json --non-interactive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,5 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          YOKAI_GOOGLE_CLIENT_ID: ${{ vars.YOKAI_GOOGLE_CLIENT_ID }}
+          YOKAI_GOOGLE_CLIENT_SECRET: ${{ vars.YOKAI_GOOGLE_CLIENT_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Release
 on:
   push:
     branches: [main]
-    # Also allow manual tag pushes as a fallback
-    tags:
-      - 'v*'
 
 permissions:
   contents: write
@@ -45,6 +42,25 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Validate release OAuth configuration
+        env:
+          YOKAI_GOOGLE_CLIENT_ID: ${{ vars.YOKAI_GOOGLE_CLIENT_ID }}
+          YOKAI_GOOGLE_CLIENT_SECRET: ${{ vars.YOKAI_GOOGLE_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          [[ -n "${YOKAI_GOOGLE_CLIENT_ID}" ]] || {
+            echo "YOKAI_GOOGLE_CLIENT_ID is not configured in firebase-production" >&2
+            exit 1
+          }
+          [[ "${YOKAI_GOOGLE_CLIENT_ID}" =~ ^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$ ]] || {
+            echo "YOKAI_GOOGLE_CLIENT_ID is not a desktop OAuth client ID" >&2
+            exit 1
+          }
+          [[ -n "${YOKAI_GOOGLE_CLIENT_SECRET}" ]] || {
+            echo "YOKAI_GOOGLE_CLIENT_SECRET is not configured in firebase-production" >&2
+            exit 1
+          }
+
       # Determine next version from commits since last tag
       - name: Determine version bump
         id: version
@@ -54,16 +70,6 @@ jobs:
           LATEST_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)
           LATEST_TAG=${LATEST_TAG:-v0.0.0}
           echo "latest_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-
-          # If this was triggered by a tag push, use that tag directly
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            echo "new_tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-            echo "skip_tag=true" >> "$GITHUB_OUTPUT"
-            echo "Using pushed tag: ${{ github.ref_name }}"
-            exit 0
-          fi
-
-          echo "skip_tag=false" >> "$GITHUB_OUTPUT"
 
           # Parse current version
           VERSION="${LATEST_TAG#v}"
@@ -95,9 +101,8 @@ jobs:
           echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
           echo "Bump: ${BUMP} (${LATEST_TAG} -> ${NEW_TAG})"
 
-      # Create and push the new tag (skip if triggered by tag push)
+      # Create and push the new tag only after the release configuration passes.
       - name: Create tag
-        if: steps.version.outputs.skip_tag == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,19 @@ jobs:
     needs: check
     if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    environment: firebase-production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Full history for changelog and version detection
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.25'
           cache: true
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -105,7 +106,7 @@ jobs:
 
       # Build and publish the release
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/
 .firebase/
 firebase-debug.log
 firestore-debug.log
+gha-creds-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bin/
 **/node_modules
 **/dist
 **/build
+.firebase/
+firebase-debug.log
+firestore-debug.log

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,12 @@ builds:
         goarch: arm64
     ldflags:
       # Strip debug info and inject version/build time
-      - -s -w -X main.version={{.Version}} -X main.buildTime={{.Date}}
+      - >-
+        -s -w
+        -X main.version={{.Version}}
+        -X main.buildTime={{.Date}}
+        -X github.com/spencerbull/yokai/internal/cloudsync.DefaultGoogleClientID={{ index .Env "YOKAI_GOOGLE_CLIENT_ID" }}
+        -X github.com/spencerbull/yokai/internal/cloudsync.DefaultGoogleClientSecret={{ index .Env "YOKAI_GOOGLE_CLIENT_SECRET" }}
 
   - id: yokai-tui
     builder: bun

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,7 @@ Tests exist for all core packages:
 | Package | Test file | What's tested |
 |---|---|---|
 | `config` | `config_test.go` | Load, save, roundtrip, device CRUD, migration, defaults |
+| `cloudsync` | `*_test.go` | Encryption compatibility, credentials, OAuth, and Firestore client behavior |
 | `agent` | `server_test.go` | HTTP endpoints, auth middleware, error handling |
 | `agent` | `metrics_test.go` | Metrics collection, JSON serialization, graceful fallback |
 | `agent` | `docker_test.go` | Container name sanitization, Docker operations |
@@ -182,7 +183,7 @@ Every pull request targeting `develop`, `staging`, or `main` runs:
 5. **Release package** -- snapshot archives for every supported platform
 6. **Firestore rules** -- isolated Firebase Emulator Suite tests
 
-All three must pass before merge.
+All six must pass before merge.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,11 +173,14 @@ Tests exist for all core packages:
 
 ### CI Checks
 
-Every pull request runs:
+Every pull request targeting `develop`, `staging`, or `main` runs:
 
-1. **Build** -- `go build ./...` across Go 1.22 and 1.23
+1. **Build** -- `go build ./...` with Go 1.25
 2. **Test** -- `go test -v -race -coverprofile=coverage.out ./...`
 3. **Lint** -- `make lint`
+4. **TUI** -- tests, bundle build, and standalone compilation
+5. **Release package** -- snapshot archives for every supported platform
+6. **Firestore rules** -- isolated Firebase Emulator Suite tests
 
 All three must pass before merge.
 
@@ -187,7 +190,7 @@ All three must pass before merge.
 
 ### Before Submitting
 
-1. **Branch from `main`**: Create a feature branch with a descriptive name.
+1. **Branch from `develop`**: Create a feature branch with a descriptive name.
    ```bash
    git checkout -b feat/add-amd-gpu-support
    git checkout -b fix/dashboard-resize-crash
@@ -206,16 +209,20 @@ All three must pass before merge.
 
 ### Submitting
 
-1. Push your branch and open a pull request against `main`.
+1. Push your branch and open a pull request against `develop`.
 2. Fill in the PR description:
    - **What** changed and **why**
    - Any breaking changes or migration notes
    - How to test the change manually (if applicable)
 3. CI will run automatically. Fix any failures before requesting review.
 
-### Review
+### Promotion and review
 
-- PRs require at least one approving review.
+- Feature PRs merge into `develop` and deploy the development backend.
+- Release candidates are promoted with a PR from `develop` to `staging`.
+- Production is promoted with a PR from `staging` to `main`.
+- Long-lived branches require passing CI, resolved threads, and approval from
+  code owner `@spencerbull`; direct pushes and force pushes are blocked.
 - Address review feedback with new commits (don't force-push during review).
 - Once approved and CI is green, the PR will be merged.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,14 @@ Your Machine                              GPU Device(s)
 
 All state lives in `~/.config/yokai/config.json`. Copy this file to another machine to reconnect to your fleet instantly.
 
+### Encrypted cloud device backup
+
+Yokai can save and load device records through an optional Firebase backend on
+Google's no-cost Spark plan. Google sign-in isolates each user's record, and
+device details are encrypted locally with a passphrase before upload. See
+[Cloud device configuration](docs/cloud-device-config.md) for deployment,
+security, cost, and usage details.
+
 ```json
 {
   "version": 1,

--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ device details are encrypted locally with a passphrase before upload. See
 [Cloud device configuration](docs/cloud-device-config.md) for deployment,
 security, cost, and usage details.
 
+```bash
+yokai cloud login             # Sign in with Google
+yokai cloud save              # Preview and create/replace the encrypted backup
+yokai cloud status --verify   # Confirm the backup and device count
+yokai cloud load              # Preview and restore devices with a local backup
+```
+
 ```json
 {
   "version": 1,

--- a/TODO.md
+++ b/TODO.md
@@ -9,9 +9,9 @@
 - [x] Map branches to `firebase-development`, `firebase-staging`, and `firebase-production` GitHub Environments.
 - [x] Move production deployment values to the production GitHub Environment and remove repository-scoped deployment values.
 - [x] Verify production is unbilled, delete-protected, keyless, least privilege, and restricted to the exact repository/branch/environment/workflow OIDC claims.
-- [ ] Obtain two additional Google Cloud project slots.
-- [ ] Create isolated unbilled Firebase development and staging projects.
-- [ ] Create per-environment web apps, Firestore databases/rules, WIF providers, deploy service accounts, and environment-scoped GitHub values.
+- [x] Obtain two additional Google Cloud project slots.
+- [x] Create isolated unbilled Firebase development and staging projects.
+- [x] Create per-environment web apps, Firestore databases/rules, WIF providers, deploy service accounts, and environment-scoped GitHub values.
 - [ ] Configure and verify Google sign-in/OAuth for each environment.
 - [ ] Exercise development and staging deployments end to end before promoting to production.
 
@@ -37,15 +37,16 @@
 - [x] Actionlint, ShellCheck, Bash syntax, and `git diff --check`.
 - [x] PR #79 GitHub checks (10/10 passing after rebase).
 - [x] Live branch ruleset, CODEOWNERS, environment branch policies, production reviewer, IAM, WIF, billing, delete protection, and service-account-key audit.
-- [ ] Live development deployment.
-- [ ] Live staging deployment.
-- [ ] Environment isolation audit proving no project ID, API key, WIF provider, or deploy service account is shared.
+- [x] Live development rules deployment from the checked-in configuration.
+- [x] Live staging rules deployment from the checked-in configuration.
+- [x] Environment isolation audit proving no project ID, API key, WIF provider, or deploy service account is shared.
+- [ ] GitHub Actions deployment from `develop` to development after PR #79 reaches `develop`.
+- [ ] GitHub Actions deployment from `staging` to staging after the promotion PR reaches `staging`.
 
 ## Open checkpoints
 
-- Google account project-count quota remains exhausted after all 17 user-approved legacy projects entered `DELETE_REQUESTED`. Google documents that soft-deleted projects may continue counting until final deletion, so continue with the quota-request fallback.
-- The quota-increase form is prepared in the signed-in Safari session for exactly two additional free-service projects; entering the account email and submitting remain at the user confirmation gate.
-- Google may require interactive passkey verification or CAPTCHA completion by the user.
+- Google approved enough project-count quota after the user submitted the request; both target projects were created successfully.
+- PR #79 must pass review and reach `develop` before the exact-claim WIF and branch-restricted development deployment can be exercised through GitHub Actions.
 - OAuth client creation is a persistent credential action and requires action-time confirmation in the Google Cloud console.
 
 ## Legacy project deletion audit
@@ -54,7 +55,7 @@
 - [x] Complete read-only resource/IAM audit for all 17 projects using three independent read-only workers.
 - [x] Identify and report projects with unexpected ownership or active infrastructure before deletion.
 - [x] Delete the confirmed exact project IDs and verify all 17 entered `DELETE_REQUESTED`.
-- [x] Re-test creation of `yokai-config-dev-260709-5820` and `yokai-config-stg-260709-5820`; Google still rejects both with the project-count quota error.
+- [x] Re-test creation of `yokai-config-dev-260709-5820` and `yokai-config-stg-260709-5820`; both were created after the quota request was approved.
 
 ### Deletion findings
 
@@ -70,8 +71,10 @@
 - PR #81 merged `.github/CODEOWNERS` with `@spencerbull` as sole owner.
 - Repository ruleset `18739747` protects `develop`, `staging`, and `main`.
 - GitHub Environments are branch-restricted: development→`develop`, staging→`staging`, production→`main`.
-- Production environment contains its Firebase project/app/API key and WIF/service-account coordinates; development and staging are intentionally empty until their projects exist.
+- All three GitHub Environments contain their own Firebase project/app/API key and WIF/service-account coordinates.
 - All 17 authorized legacy project IDs report lifecycle state `DELETE_REQUESTED`.
 - PR #79 targets `develop`, is mergeable, and its latest complete CI run has ten successful checks.
 - Live re-audit confirms exact branch-to-environment policies, the active long-lived-branch ruleset, sole `@spencerbull` code ownership, no repository-scoped deployment variables, and the production environment's branch/reviewer controls.
 - Production remains unbilled and Firestore-delete-protected, has no user-managed deploy-service-account keys, and uses exact repository/branch/environment/workflow OIDC claims with only the custom Firebase Rules deployer role.
+- Development and staging are unbilled Firebase Spark projects with `us-central1` Firestore Native databases, delete protection, deployed rules, dedicated web apps, exact-claim WIF providers, custom rules-deployer roles, and no user-managed service-account keys.
+- SHA-256 comparisons confirm that the three Firebase API keys are distinct without recording the raw values in the audit ledger.

--- a/TODO.md
+++ b/TODO.md
@@ -24,8 +24,8 @@
 
 ## Allowed and forbidden actions
 
-- Allowed: create the two named unbilled Firebase projects, configure Firebase/WIF/GitHub Environments, submit the disclosed Google project-quota request, run tests, and update PR #79.
-- Forbidden without a new explicit approval: enable billing, delete or repurpose unrelated Google Cloud projects, deploy application code outside the three named environments, rotate unrelated credentials, or mutate customer data.
+- Allowed: create the two named unbilled Firebase projects, configure Firebase/WIF/GitHub Environments, submit the disclosed Google project-quota request, delete the 17 exact legacy project IDs authorized below, run tests, and update PR #79.
+- Forbidden without a new explicit approval: enable billing, delete or repurpose any other Google Cloud project, deploy application code outside the three named environments, rotate unrelated credentials, or mutate customer data.
 
 ## Required verification
 
@@ -43,8 +43,9 @@
 
 ## Open checkpoints
 
-- Google account project-count quota is exhausted. The quota form is paused while 17 user-approved legacy projects are audited for deletion. Google documents that soft-deleted projects may continue counting until final deletion, so retain the quota-request fallback.
-- Google may require interactive sign-in, passkey verification, or CAPTCHA completion by the user.
+- Google account project-count quota remains exhausted after all 17 user-approved legacy projects entered `DELETE_REQUESTED`. Google documents that soft-deleted projects may continue counting until final deletion, so continue with the quota-request fallback.
+- The quota-increase form is prepared in the signed-in Safari session for exactly two additional free-service projects; entering the account email and submitting remain at the user confirmation gate.
+- Google may require interactive passkey verification or CAPTCHA completion by the user.
 - OAuth client creation is a persistent credential action and requires action-time confirmation in the Google Cloud console.
 
 ## Legacy project deletion audit
@@ -52,8 +53,8 @@
 - User-authorized names map to: `tidy-campaign-774`, `promising-howl-798`, `notspotify-162300`, `bullrhinobot`, `cs-bot-168319`, `dellctovoice`, `dell-assistant-fda98`, `slipspace-bullapse`, `contextual-coach`, `dell-contextual-tasks-79a3b`, `dell-contextual-tasks-5b3dd`, `dell-contextual-tasks`, `dellcontextualtasks`, `contextual-tasks`, `contextual-tasks-1565883164223`, `vzre-256101`, and `spaceos`.
 - [x] Complete read-only resource/IAM audit for all 17 projects using three independent read-only workers.
 - [x] Identify and report projects with unexpected ownership or active infrastructure before deletion.
-- [ ] Delete the confirmed exact project IDs and record operation results.
-- [ ] Re-test creation of the development and staging project IDs.
+- [x] Delete the confirmed exact project IDs and verify all 17 entered `DELETE_REQUESTED`.
+- [x] Re-test creation of `yokai-config-dev-260709-5820`; Google still rejects it with the project-count quota error.
 
 ### Deletion findings
 
@@ -61,7 +62,8 @@
 - External-access risk: `dellctovoice` has three non-Spencer human editors, although no deployed resources were discovered.
 - Residual/uncertain legacy state: `tidy-campaign-774`, `promising-howl-798`, `dell-assistant-fda98`, and `vzre-256101` have App Engine or initialized Firebase surfaces that cannot be completely enumerated while billing is disabled.
 - Low observed risk: the remaining audited projects have no billing, no non-Spencer human principals, and no observed deployed code or non-empty databases/storage at the inspected surfaces.
-- [ ] Receive final confirmation to delete all 17 exact project IDs despite the disclosed active source, function, database, artifact, and collaborator impact.
+- [x] Receive continuation authorization after disclosing the active source, function, database, artifact, and collaborator impact.
+- [x] Delete the Dialogflow agents and stale Resource Manager liens that initially blocked `dellctovoice` and `dell-assistant-fda98` deletion.
 
 ## Completed evidence
 
@@ -69,4 +71,5 @@
 - Repository ruleset `18739747` protects `develop`, `staging`, and `main`.
 - GitHub Environments are branch-restricted: development→`develop`, staging→`staging`, production→`main`.
 - Production environment contains its Firebase project/app/API key and WIF/service-account coordinates; development and staging are intentionally empty until their projects exist.
-- PR #79 head `386afca` targets `develop` and has ten successful checks.
+- All 17 authorized legacy project IDs report lifecycle state `DELETE_REQUESTED`.
+- PR #79 head `20f47dd` targets `develop` and has ten successful checks.

--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,7 @@
 - [x] Complete read-only resource/IAM audit for all 17 projects using three independent read-only workers.
 - [x] Identify and report projects with unexpected ownership or active infrastructure before deletion.
 - [x] Delete the confirmed exact project IDs and verify all 17 entered `DELETE_REQUESTED`.
-- [x] Re-test creation of `yokai-config-dev-260709-5820`; Google still rejects it with the project-count quota error.
+- [x] Re-test creation of `yokai-config-dev-260709-5820` and `yokai-config-stg-260709-5820`; Google still rejects both with the project-count quota error.
 
 ### Deletion findings
 
@@ -72,4 +72,6 @@
 - GitHub Environments are branch-restricted: development→`develop`, staging→`staging`, production→`main`.
 - Production environment contains its Firebase project/app/API key and WIF/service-account coordinates; development and staging are intentionally empty until their projects exist.
 - All 17 authorized legacy project IDs report lifecycle state `DELETE_REQUESTED`.
-- PR #79 head `20f47dd` targets `develop` and has ten successful checks.
+- PR #79 head `732d881` targets `develop`, is mergeable, and has ten successful checks.
+- Live re-audit confirms exact branch-to-environment policies, the active long-lived-branch ruleset, sole `@spencerbull` code ownership, no repository-scoped deployment variables, and the production environment's branch/reviewer controls.
+- Production remains unbilled and Firestore-delete-protected, has no user-managed deploy-service-account keys, and uses exact repository/branch/environment/workflow OIDC claims with only the custom Firebase Rules deployer role.

--- a/TODO.md
+++ b/TODO.md
@@ -72,6 +72,6 @@
 - GitHub Environments are branch-restricted: development→`develop`, staging→`staging`, production→`main`.
 - Production environment contains its Firebase project/app/API key and WIF/service-account coordinates; development and staging are intentionally empty until their projects exist.
 - All 17 authorized legacy project IDs report lifecycle state `DELETE_REQUESTED`.
-- PR #79 head `732d881` targets `develop`, is mergeable, and has ten successful checks.
+- PR #79 targets `develop`, is mergeable, and its latest complete CI run has ten successful checks.
 - Live re-audit confirms exact branch-to-environment policies, the active long-lived-branch ruleset, sole `@spencerbull` code ownership, no repository-scoped deployment variables, and the production environment's branch/reviewer controls.
 - Production remains unbilled and Firestore-delete-protected, has no user-managed deploy-service-account keys, and uses exact repository/branch/environment/workflow OIDC claims with only the custom Firebase Rules deployer role.

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - [x] Create isolated unbilled Firebase development and staging projects.
 - [x] Create per-environment web apps, Firestore databases/rules, WIF providers, deploy service accounts, and environment-scoped GitHub values.
 - [x] Configure and verify Google sign-in/OAuth for each environment.
+- [x] Complete the pre-merge cloud-config UX and destructive-action safety pass.
 - [ ] Exercise development and staging deployments end to end before promoting to production.
 
 ## Streams and worktrees
@@ -42,6 +43,9 @@
 - [x] Environment isolation audit proving no project ID, API key, WIF provider, or deploy service account is shared.
 - [x] OAuth isolation audit proving each environment has its own desktop client ID/secret and enabled Google provider.
 - [x] Live development login, encrypted save, status, load, server-side delete, and local logout smoke test.
+- [x] UX regression tests prove every cloud subcommand's help exits before actions and empty device lists are blocked by default.
+- [x] Focused cloud CLI/sync race tests, golangci-lint, and all OpenTUI tests pass after the UX pass.
+- [x] Independent review of the final UX/safety diff is resolved or documented.
 - [x] Three independent PR review passes covering security, Actions/governance, and documentation/tests; verified actionable findings were fixed.
 - [x] Live Firebase API keys restricted to Identity Toolkit and Secure Token in all three projects, with allowed-API smoke responses verified in development.
 - [x] Live rulesets split so CI/thread/direct-push controls have no bypass; production environment admin bypass disabled.
@@ -53,6 +57,7 @@
 - Google approved enough project-count quota after the user submitted the request; both target projects were created successfully.
 - PR #79 must pass review and reach `develop` before the exact-claim WIF and branch-restricted development deployment can be exercised through GitHub Actions.
 - All three OAuth audiences are restricted to Testing with `spencerbull2554@gmail.com` as the sole test user. Publishing production is an explicit release gate; development and staging stay unpublished.
+- User review of the improved cloud-config flow is now a checkpoint before production OAuth changes or PR merge approval.
 
 ## Legacy project deletion audit
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,14 +5,14 @@
 - [x] Create long-lived `develop`, `staging`, and `main` branches.
 - [x] Make `develop` the default branch and retarget feature PR #79.
 - [x] Require PRs, passing CI, resolved threads, and `@spencerbull` code-owner approval on all long-lived branches.
-- [x] Block direct pushes, force pushes, and deletion; allow Spencer to bypass approval only while merging a PR.
+- [x] Block direct pushes, force pushes, and deletion; keep CI/thread gates non-bypassable and allow Spencer to bypass only the self-approval rule while merging a PR.
 - [x] Map branches to `firebase-development`, `firebase-staging`, and `firebase-production` GitHub Environments.
 - [x] Move production deployment values to the production GitHub Environment and remove repository-scoped deployment values.
 - [x] Verify production is unbilled, delete-protected, keyless, least privilege, and restricted to the exact repository/branch/environment/workflow OIDC claims.
 - [x] Obtain two additional Google Cloud project slots.
 - [x] Create isolated unbilled Firebase development and staging projects.
 - [x] Create per-environment web apps, Firestore databases/rules, WIF providers, deploy service accounts, and environment-scoped GitHub values.
-- [ ] Configure and verify Google sign-in/OAuth for each environment.
+- [x] Configure and verify Google sign-in/OAuth for each environment.
 - [ ] Exercise development and staging deployments end to end before promoting to production.
 
 ## Streams and worktrees
@@ -40,6 +40,11 @@
 - [x] Live development rules deployment from the checked-in configuration.
 - [x] Live staging rules deployment from the checked-in configuration.
 - [x] Environment isolation audit proving no project ID, API key, WIF provider, or deploy service account is shared.
+- [x] OAuth isolation audit proving each environment has its own desktop client ID/secret and enabled Google provider.
+- [x] Live development login, encrypted save, status, load, server-side delete, and local logout smoke test.
+- [x] Three independent PR review passes covering security, Actions/governance, and documentation/tests; verified actionable findings were fixed.
+- [x] Live Firebase API keys restricted to Identity Toolkit and Secure Token in all three projects, with allowed-API smoke responses verified in development.
+- [x] Live rulesets split so CI/thread/direct-push controls have no bypass; production environment admin bypass disabled.
 - [ ] GitHub Actions deployment from `develop` to development after PR #79 reaches `develop`.
 - [ ] GitHub Actions deployment from `staging` to staging after the promotion PR reaches `staging`.
 
@@ -47,7 +52,7 @@
 
 - Google approved enough project-count quota after the user submitted the request; both target projects were created successfully.
 - PR #79 must pass review and reach `develop` before the exact-claim WIF and branch-restricted development deployment can be exercised through GitHub Actions.
-- OAuth client creation is a persistent credential action and requires action-time confirmation in the Google Cloud console.
+- All three OAuth audiences are restricted to Testing with `spencerbull2554@gmail.com` as the sole test user. Publishing production is an explicit release gate; development and staging stay unpublished.
 
 ## Legacy project deletion audit
 
@@ -78,3 +83,8 @@
 - Production remains unbilled and Firestore-delete-protected, has no user-managed deploy-service-account keys, and uses exact repository/branch/environment/workflow OIDC claims with only the custom Firebase Rules deployer role.
 - Development and staging are unbilled Firebase Spark projects with `us-central1` Firestore Native databases, delete protection, deployed rules, dedicated web apps, exact-claim WIF providers, custom rules-deployer roles, and no user-managed service-account keys.
 - SHA-256 comparisons confirm that the three Firebase API keys are distinct without recording the raw values in the audit ledger.
+- Firebase Authentication and Google sign-in are enabled in all three unbilled projects. Each GitHub Environment contains a distinct desktop OAuth client ID and secret whose project-number prefix matches its Firebase project.
+- The development OAuth flow completed through Safari and the CLI successfully exercised login, encrypted save, status, load, server-side delete, and logout. The smoke-test record and local credentials were removed afterward.
+- The superseded development OAuth secret is disabled; the verified replacement remains enabled and stored only in the development GitHub Environment.
+- Public Firebase keys in development, staging, and production allow only `identitytoolkit.googleapis.com` and `securetoken.googleapis.com`.
+- Ruleset `18739747` has no bypass actors and enforces branch/CI/thread controls; approval ruleset `18892833` contains the sole PR-only maintainer bypass.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,72 @@
+# Three-environment Firebase rollout
+
+## Goal and done criteria
+
+- [x] Create long-lived `develop`, `staging`, and `main` branches.
+- [x] Make `develop` the default branch and retarget feature PR #79.
+- [x] Require PRs, passing CI, resolved threads, and `@spencerbull` code-owner approval on all long-lived branches.
+- [x] Block direct pushes, force pushes, and deletion; allow Spencer to bypass approval only while merging a PR.
+- [x] Map branches to `firebase-development`, `firebase-staging`, and `firebase-production` GitHub Environments.
+- [x] Move production deployment values to the production GitHub Environment and remove repository-scoped deployment values.
+- [x] Verify production is unbilled, delete-protected, keyless, least privilege, and restricted to the exact repository/branch/environment/workflow OIDC claims.
+- [ ] Obtain two additional Google Cloud project slots.
+- [ ] Create isolated unbilled Firebase development and staging projects.
+- [ ] Create per-environment web apps, Firestore databases/rules, WIF providers, deploy service accounts, and environment-scoped GitHub values.
+- [ ] Configure and verify Google sign-in/OAuth for each environment.
+- [ ] Exercise development and staging deployments end to end before promoting to production.
+
+## Streams and worktrees
+
+| Stream | Branch | Worktree | Scope |
+|---|---|---|---|
+| Cloud config feature | `agent/cloud-config-sync` | `/tmp/Yokai-cloud-config` | PR #79 implementation, workflows, scripts, docs |
+| Code-owner bootstrap | merged PR #81 | `/tmp/Yokai-governance-bootstrap` | `.github/CODEOWNERS` only |
+
+## Allowed and forbidden actions
+
+- Allowed: create the two named unbilled Firebase projects, configure Firebase/WIF/GitHub Environments, submit the disclosed Google project-quota request, run tests, and update PR #79.
+- Forbidden without a new explicit approval: enable billing, delete or repurpose unrelated Google Cloud projects, deploy application code outside the three named environments, rotate unrelated credentials, or mutate customer data.
+
+## Required verification
+
+- [x] Go race tests for changed packages.
+- [x] golangci-lint.
+- [x] Firestore Emulator Suite rules tests (5/5).
+- [x] OpenTUI tests/build/compile.
+- [x] GoReleaser snapshot and archive verification.
+- [x] Actionlint, ShellCheck, Bash syntax, and `git diff --check`.
+- [x] PR #79 GitHub checks (10/10 passing after rebase).
+- [x] Live branch ruleset, CODEOWNERS, environment branch policies, production reviewer, IAM, WIF, billing, delete protection, and service-account-key audit.
+- [ ] Live development deployment.
+- [ ] Live staging deployment.
+- [ ] Environment isolation audit proving no project ID, API key, WIF provider, or deploy service account is shared.
+
+## Open checkpoints
+
+- Google account project-count quota is exhausted. The quota form is paused while 17 user-approved legacy projects are audited for deletion. Google documents that soft-deleted projects may continue counting until final deletion, so retain the quota-request fallback.
+- Google may require interactive sign-in, passkey verification, or CAPTCHA completion by the user.
+- OAuth client creation is a persistent credential action and requires action-time confirmation in the Google Cloud console.
+
+## Legacy project deletion audit
+
+- User-authorized names map to: `tidy-campaign-774`, `promising-howl-798`, `notspotify-162300`, `bullrhinobot`, `cs-bot-168319`, `dellctovoice`, `dell-assistant-fda98`, `slipspace-bullapse`, `contextual-coach`, `dell-contextual-tasks-79a3b`, `dell-contextual-tasks-5b3dd`, `dell-contextual-tasks`, `dellcontextualtasks`, `contextual-tasks`, `contextual-tasks-1565883164223`, `vzre-256101`, and `spaceos`.
+- [x] Complete read-only resource/IAM audit for all 17 projects using three independent read-only workers.
+- [x] Identify and report projects with unexpected ownership or active infrastructure before deletion.
+- [ ] Delete the confirmed exact project IDs and record operation results.
+- [ ] Re-test creation of the development and staging project IDs.
+
+### Deletion findings
+
+- High data-loss risk: `notspotify-162300` has two external editors, a Cloud Source repository, source files, and about 2.66 GiB of container artifacts; `bullrhinobot` has two Cloud Source repositories and about 361 MiB of container artifacts; `slipspace-bullapse` has three active Cloud Functions, Hosting deployment history, and a Firestore database.
+- External-access risk: `dellctovoice` has three non-Spencer human editors, although no deployed resources were discovered.
+- Residual/uncertain legacy state: `tidy-campaign-774`, `promising-howl-798`, `dell-assistant-fda98`, and `vzre-256101` have App Engine or initialized Firebase surfaces that cannot be completely enumerated while billing is disabled.
+- Low observed risk: the remaining audited projects have no billing, no non-Spencer human principals, and no observed deployed code or non-empty databases/storage at the inspected surfaces.
+- [ ] Receive final confirmation to delete all 17 exact project IDs despite the disclosed active source, function, database, artifact, and collaborator impact.
+
+## Completed evidence
+
+- PR #81 merged `.github/CODEOWNERS` with `@spencerbull` as sole owner.
+- Repository ruleset `18739747` protects `develop`, `staging`, and `main`.
+- GitHub Environments are branch-restricted: development→`develop`, staging→`staging`, production→`main`.
+- Production environment contains its Firebase project/app/API key and WIF/service-account coordinates; development and staging are intentionally empty until their projects exist.
+- PR #79 head `386afca` targets `develop` and has ten successful checks.

--- a/cmd/yokai/main.go
+++ b/cmd/yokai/main.go
@@ -121,9 +121,9 @@ Configuration:
 
 Cloud Device Config:
   yokai cloud login [flags]                  Sign in with Google
-  yokai cloud save                           Encrypt and save device config
-  yokai cloud load                           Load devices (backs up local config)
-  yokai cloud status                         Show cloud login status
+  yokai cloud save [--yes]                   Encrypt and back up local devices
+  yokai cloud load [--yes]                   Preview and restore cloud devices
+  yokai cloud status [--verify]              Show login and backup status
   yokai cloud delete --yes                   Delete the cloud copy
   yokai cloud logout                         Remove local Google credentials
 

--- a/cmd/yokai/main.go
+++ b/cmd/yokai/main.go
@@ -51,6 +51,9 @@ func main() {
 		case "config":
 			cli.RunConfig(os.Args[2:])
 			return
+		case "cloud":
+			cli.RunCloud(os.Args[2:])
+			return
 
 		case "--help", "-h":
 			printUsage()
@@ -115,6 +118,14 @@ Configuration:
   yokai config show                          Dump config (tokens redacted)
   yokai config set <key> <value>             Set a config value
   yokai config path                          Print config file path
+
+Cloud Device Config:
+  yokai cloud login [flags]                  Sign in with Google
+  yokai cloud save                           Encrypt and save device config
+  yokai cloud load                           Load devices (backs up local config)
+  yokai cloud status                         Show cloud login status
+  yokai cloud delete --yes                   Delete the cloud copy
+  yokai cloud logout                         Remove local Google credentials
 
 All CLI commands output JSON to stdout. Errors go to stderr as JSON.
 `, version)

--- a/deploy/gcp/setup-common.sh
+++ b/deploy/gcp/setup-common.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+verify_spark_billing() {
+  local project_id="$1" allow_billed_project="$2" billing_enabled
+  if ! billing_enabled="$(gcloud billing projects describe "${project_id}" --format='value(billingEnabled)')"; then
+    printf 'unable to verify billing state for project %s; refusing to provision\n' "${project_id}" >&2
+    return 1
+  fi
+  case "${billing_enabled}" in
+    False) return 0 ;;
+    True)
+      if [[ "${allow_billed_project}" == "1" ]]; then
+        return 0
+      fi
+      printf 'project %s has billing enabled; use an unbilled project for Spark or set ALLOW_BILLED_PROJECT=1\n' "${project_id}" >&2
+      return 1
+      ;;
+    *)
+      printf 'unexpected billing state %q for project %s; refusing to provision\n' "${billing_enabled}" "${project_id}" >&2
+      return 1
+      ;;
+  esac
+}
+
+firebase_app_match_count() {
+  local apps_json="$1" display_name="$2"
+  jq -r --arg name "${display_name}" '[.result[] | select(.displayName == $name)] | length' <<<"${apps_json}"
+}
+
+firebase_app_id() {
+  local apps_json="$1" display_name="$2" count
+  count="$(firebase_app_match_count "${apps_json}" "${display_name}")"
+  if [[ "${count}" != "1" ]]; then
+    printf 'expected exactly one Firebase web app named %q, found %s\n' "${display_name}" "${count}" >&2
+    return 1
+  fi
+  jq -r --arg name "${display_name}" '.result[] | select(.displayName == $name) | .appId' <<<"${apps_json}"
+}

--- a/deploy/gcp/setup-firebase.sh
+++ b/deploy/gcp/setup-firebase.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID to a Google Cloud project without billing}"
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID to the environment-specific Google Cloud project ID}"
+: "${DEPLOY_STAGE:?Set DEPLOY_STAGE to development, staging, or production}"
+
+case "${DEPLOY_STAGE}" in
+  development|staging|production) ;;
+  *) printf 'DEPLOY_STAGE must be development, staging, or production\n' >&2; exit 1 ;;
+esac
 
 REGION="${GCP_REGION:-us-central1}"
+PROJECT_DISPLAY_NAME="${GCP_PROJECT_DISPLAY_NAME:-Yokai Config ${DEPLOY_STAGE}}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
 command -v firebase >/dev/null || { printf 'firebase-tools is required\n' >&2; exit 1; }
+command -v jq >/dev/null || { printf 'jq is required\n' >&2; exit 1; }
+
+if ! gcloud projects describe "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+  if [[ "${CREATE_PROJECT:-0}" != "1" ]]; then
+    printf 'project %s does not exist; set CREATE_PROJECT=1 to create it\n' "${GCP_PROJECT_ID}" >&2
+    exit 1
+  fi
+  gcloud projects create "${GCP_PROJECT_ID}" --name="${PROJECT_DISPLAY_NAME}"
+fi
 
 BILLING_ENABLED="$(gcloud billing projects describe "${GCP_PROJECT_ID}" --format='value(billingEnabled)' 2>/dev/null || true)"
 if [[ "${BILLING_ENABLED}" == "True" && "${ALLOW_BILLED_PROJECT:-0}" != "1" ]]; then
@@ -15,31 +31,43 @@ if [[ "${BILLING_ENABLED}" == "True" && "${ALLOW_BILLED_PROJECT:-0}" != "1" ]]; 
   exit 1
 fi
 
-gcloud config set project "${GCP_PROJECT_ID}"
 gcloud services enable \
   firebase.googleapis.com \
   firebaserules.googleapis.com \
   firestore.googleapis.com \
   identitytoolkit.googleapis.com \
-  securetoken.googleapis.com
+  securetoken.googleapis.com \
+  --project "${GCP_PROJECT_ID}"
 
-if ! firebase projects:list --json | grep -q "\"projectId\": \"${GCP_PROJECT_ID}\""; then
+if ! firebase projects:list --json | jq -e --arg project "${GCP_PROJECT_ID}" '.result[] | select(.projectId == $project)' >/dev/null; then
   firebase projects:addfirebase "${GCP_PROJECT_ID}"
 fi
 
-if ! gcloud firestore databases describe --database='(default)' >/dev/null 2>&1; then
+if ! gcloud firestore databases describe --project "${GCP_PROJECT_ID}" --database='(default)' >/dev/null 2>&1; then
   gcloud firestore databases create \
+    --project "${GCP_PROJECT_ID}" \
     --database='(default)' \
     --location="${REGION}" \
     --type=firestore-native
 fi
 
-if ! firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json | grep -q 'appId'; then
-  firebase apps:create WEB "Yokai CLI" --project "${GCP_PROJECT_ID}"
+gcloud firestore databases update \
+  --project "${GCP_PROJECT_ID}" \
+  --database='(default)' \
+  --delete-protection \
+  --quiet >/dev/null
+
+APPS="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json)"
+if ! jq -e '.result[0].appId' <<<"${APPS}" >/dev/null; then
+  firebase apps:create WEB "Yokai CLI ${DEPLOY_STAGE}" --project "${GCP_PROJECT_ID}"
+  APPS="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json)"
 fi
 
 firebase deploy --only firestore:rules --project "${GCP_PROJECT_ID}" --config "${REPO_ROOT}/firebase.json"
 
-APP_ID="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json | sed -n 's/.*"appId": "\([^"]*\)".*/\1/p' | head -1)"
-printf 'Firebase backend is ready. Public client configuration:\n'
-firebase apps:sdkconfig WEB "${APP_ID}" --project "${GCP_PROJECT_ID}"
+APP_ID="$(jq -r '.result[0].appId' <<<"${APPS}")"
+SDK_CONFIG="$(firebase apps:sdkconfig WEB "${APP_ID}" --project "${GCP_PROJECT_ID}" --json)"
+printf 'Firebase %s backend is ready.\n' "${DEPLOY_STAGE}"
+printf 'Project ID: %s\n' "${GCP_PROJECT_ID}"
+printf 'App ID: %s\n' "$(jq -r '.result.sdkConfig.appId' <<<"${SDK_CONFIG}")"
+printf 'API key: %s\n' "$(jq -r '.result.sdkConfig.apiKey' <<<"${SDK_CONFIG}")"

--- a/deploy/gcp/setup-firebase.sh
+++ b/deploy/gcp/setup-firebase.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID to a Google Cloud project without billing}"
+
+REGION="${GCP_REGION:-us-central1}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
+command -v firebase >/dev/null || { printf 'firebase-tools is required\n' >&2; exit 1; }
+
+gcloud config set project "${GCP_PROJECT_ID}"
+gcloud services enable \
+  firebase.googleapis.com \
+  firebaserules.googleapis.com \
+  firestore.googleapis.com \
+  identitytoolkit.googleapis.com \
+  securetoken.googleapis.com
+
+if ! firebase projects:list --json | grep -q "\"projectId\": \"${GCP_PROJECT_ID}\""; then
+  firebase projects:addfirebase "${GCP_PROJECT_ID}"
+fi
+
+if ! gcloud firestore databases describe --database='(default)' >/dev/null 2>&1; then
+  gcloud firestore databases create \
+    --database='(default)' \
+    --location="${REGION}" \
+    --type=firestore-native
+fi
+
+if ! firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json | grep -q 'appId'; then
+  firebase apps:create WEB "Yokai CLI" --project "${GCP_PROJECT_ID}"
+fi
+
+firebase deploy --only firestore:rules --project "${GCP_PROJECT_ID}" --config "${REPO_ROOT}/firebase.json"
+
+APP_ID="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json | sed -n 's/.*"appId": "\([^"]*\)".*/\1/p' | head -1)"
+printf 'Firebase backend is ready. Public client configuration:\n'
+firebase apps:sdkconfig WEB "${APP_ID}" --project "${GCP_PROJECT_ID}"

--- a/deploy/gcp/setup-firebase.sh
+++ b/deploy/gcp/setup-firebase.sh
@@ -17,6 +17,45 @@ command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
 command -v firebase >/dev/null || { printf 'firebase-tools is required\n' >&2; exit 1; }
 command -v jq >/dev/null || { printf 'jq is required\n' >&2; exit 1; }
 
+FIREBASE_LIST_DIAGNOSTIC=""
+firebase_project_state() {
+  local error_file output
+  if ! error_file="$(mktemp)"; then
+    FIREBASE_LIST_DIAGNOSTIC="Unable to create a temporary file for Firebase CLI diagnostics."
+    return 2
+  fi
+  if output="$(firebase projects:list --json 2>"${error_file}")"; then
+    FIREBASE_LIST_DIAGNOSTIC="$(<"${error_file}")"
+  else
+    FIREBASE_LIST_DIAGNOSTIC="$(<"${error_file}")"
+    rm -f "${error_file}"
+    [[ -n "${output}" ]] && FIREBASE_LIST_DIAGNOSTIC+=$'\n'"${output}"
+    return 2
+  fi
+  rm -f "${error_file}"
+
+  if ! jq -e '.result | type == "array"' <<<"${output}" >/dev/null 2>&1; then
+    FIREBASE_LIST_DIAGNOSTIC+=$'\nFirebase projects:list returned unexpected JSON.'
+    return 2
+  fi
+  if jq -e --arg project "${GCP_PROJECT_ID}" \
+    '.result[] | select(.projectId == $project)' <<<"${output}" >/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+wait_for_firebase_project() {
+  local attempt state
+  for attempt in {1..8}; do
+    state=0
+    firebase_project_state || state=$?
+    [[ "${state}" == "0" ]] && return 0
+    (( attempt < 8 )) && sleep 3
+  done
+  return "${state}"
+}
+
 if ! gcloud projects describe "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
   if [[ "${CREATE_PROJECT:-0}" != "1" ]]; then
     printf 'project %s does not exist; set CREATE_PROJECT=1 to create it\n' "${GCP_PROJECT_ID}" >&2
@@ -39,8 +78,29 @@ gcloud services enable \
   securetoken.googleapis.com \
   --project "${GCP_PROJECT_ID}"
 
-if ! firebase projects:list --json | jq -e --arg project "${GCP_PROJECT_ID}" '.result[] | select(.projectId == $project)' >/dev/null; then
-  firebase projects:addfirebase "${GCP_PROJECT_ID}"
+FIREBASE_STATE=0
+firebase_project_state || FIREBASE_STATE=$?
+if [[ "${FIREBASE_STATE}" == "2" ]]; then
+  printf '%s\n' "${FIREBASE_LIST_DIAGNOSTIC}" >&2
+  exit 1
+fi
+if [[ "${FIREBASE_STATE}" == "1" ]]; then
+  # addFirebase can finish server-side before the project appears in listProjects.
+  # Treat a failed add as recoverable only when the project subsequently becomes visible.
+  ADD_FIREBASE_OUTPUT=""
+  if ADD_FIREBASE_OUTPUT="$(firebase projects:addfirebase "${GCP_PROJECT_ID}" 2>&1)"; then
+    ADD_FIREBASE_STATUS=0
+  else
+    ADD_FIREBASE_STATUS=$?
+  fi
+  FIREBASE_STATE=0
+  wait_for_firebase_project || FIREBASE_STATE=$?
+  if [[ "${FIREBASE_STATE}" != "0" ]]; then
+    [[ "${ADD_FIREBASE_STATUS}" != "0" ]] && printf '%s\n' "${ADD_FIREBASE_OUTPUT}" >&2
+    [[ -n "${FIREBASE_LIST_DIAGNOSTIC}" ]] && printf '%s\n' "${FIREBASE_LIST_DIAGNOSTIC}" >&2
+    printf 'Firebase project %s did not become ready after addFirebase\n' "${GCP_PROJECT_ID}" >&2
+    exit 1
+  fi
 fi
 
 if ! gcloud firestore databases describe --project "${GCP_PROJECT_ID}" --database='(default)' >/dev/null 2>&1; then
@@ -51,11 +111,26 @@ if ! gcloud firestore databases describe --project "${GCP_PROJECT_ID}" --databas
     --type=firestore-native
 fi
 
-gcloud firestore databases update \
-  --project "${GCP_PROJECT_ID}" \
-  --database='(default)' \
-  --delete-protection \
-  --quiet >/dev/null
+for attempt in {1..8}; do
+  if UPDATE_OUTPUT="$(gcloud firestore databases update \
+    --project "${GCP_PROJECT_ID}" \
+    --database='(default)' \
+    --delete-protection \
+    --quiet 2>&1)"; then
+    break
+  fi
+
+  if [[ "${UPDATE_OUTPUT}" != *"ABORTED"* && "${UPDATE_OUTPUT}" != *"PERMISSION_DENIED"* ]]; then
+    printf '%s\n' "${UPDATE_OUTPUT}" >&2
+    exit 1
+  fi
+  if (( attempt == 8 )); then
+    printf '%s\n' "${UPDATE_OUTPUT}" >&2
+    printf 'Firestore delete protection did not become writable in time\n' >&2
+    exit 1
+  fi
+  sleep 3
+done
 
 APPS="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json)"
 if ! jq -e '.result[0].appId' <<<"${APPS}" >/dev/null; then

--- a/deploy/gcp/setup-firebase.sh
+++ b/deploy/gcp/setup-firebase.sh
@@ -9,9 +9,17 @@ case "${DEPLOY_STAGE}" in
   *) printf 'DEPLOY_STAGE must be development, staging, or production\n' >&2; exit 1 ;;
 esac
 
+if [[ "${DEPLOY_STAGE}" == "production" ]]; then
+  FIREBASE_APP_DISPLAY_NAME="${FIREBASE_APP_DISPLAY_NAME:-Yokai CLI}"
+else
+  FIREBASE_APP_DISPLAY_NAME="${FIREBASE_APP_DISPLAY_NAME:-Yokai CLI ${DEPLOY_STAGE}}"
+fi
+
 REGION="${GCP_REGION:-us-central1}"
 PROJECT_DISPLAY_NAME="${GCP_PROJECT_DISPLAY_NAME:-Yokai Config ${DEPLOY_STAGE}}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=setup-common.sh
+source "${REPO_ROOT}/deploy/gcp/setup-common.sh"
 
 command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
 command -v firebase >/dev/null || { printf 'firebase-tools is required\n' >&2; exit 1; }
@@ -64,11 +72,7 @@ if ! gcloud projects describe "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
   gcloud projects create "${GCP_PROJECT_ID}" --name="${PROJECT_DISPLAY_NAME}"
 fi
 
-BILLING_ENABLED="$(gcloud billing projects describe "${GCP_PROJECT_ID}" --format='value(billingEnabled)' 2>/dev/null || true)"
-if [[ "${BILLING_ENABLED}" == "True" && "${ALLOW_BILLED_PROJECT:-0}" != "1" ]]; then
-  printf 'project %s has billing enabled; use an unbilled project for Spark or set ALLOW_BILLED_PROJECT=1\n' "${GCP_PROJECT_ID}" >&2
-  exit 1
-fi
+verify_spark_billing "${GCP_PROJECT_ID}" "${ALLOW_BILLED_PROJECT:-0}"
 
 gcloud services enable \
   firebase.googleapis.com \
@@ -133,16 +137,30 @@ for attempt in {1..8}; do
 done
 
 APPS="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json)"
-if ! jq -e '.result[0].appId' <<<"${APPS}" >/dev/null; then
-  firebase apps:create WEB "Yokai CLI ${DEPLOY_STAGE}" --project "${GCP_PROJECT_ID}"
+APP_MATCH_COUNT="$(firebase_app_match_count "${APPS}" "${FIREBASE_APP_DISPLAY_NAME}")"
+if [[ "${APP_MATCH_COUNT}" == "0" ]]; then
+  firebase apps:create WEB "${FIREBASE_APP_DISPLAY_NAME}" --project "${GCP_PROJECT_ID}"
   APPS="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json)"
+  APP_MATCH_COUNT="$(firebase_app_match_count "${APPS}" "${FIREBASE_APP_DISPLAY_NAME}")"
+fi
+if [[ "${APP_MATCH_COUNT}" != "1" ]]; then
+  printf 'expected exactly one Firebase web app named %q, found %s\n' "${FIREBASE_APP_DISPLAY_NAME}" "${APP_MATCH_COUNT}" >&2
+  exit 1
 fi
 
 firebase deploy --only firestore:rules --project "${GCP_PROJECT_ID}" --config "${REPO_ROOT}/firebase.json"
 
-APP_ID="$(jq -r '.result[0].appId' <<<"${APPS}")"
+APP_ID="$(firebase_app_id "${APPS}" "${FIREBASE_APP_DISPLAY_NAME}")"
 SDK_CONFIG="$(firebase apps:sdkconfig WEB "${APP_ID}" --project "${GCP_PROJECT_ID}" --json)"
+API_KEY="$(jq -r '.result.sdkConfig.apiKey' <<<"${SDK_CONFIG}")"
+API_KEY_NAME="$(gcloud services api-keys lookup "${API_KEY}" --project "${GCP_PROJECT_ID}" --format='value(name)')"
+gcloud services api-keys update "${API_KEY_NAME}" \
+  --project "${GCP_PROJECT_ID}" \
+  --api-target=service=identitytoolkit.googleapis.com \
+  --api-target=service=securetoken.googleapis.com \
+  --quiet >/dev/null
+
 printf 'Firebase %s backend is ready.\n' "${DEPLOY_STAGE}"
 printf 'Project ID: %s\n' "${GCP_PROJECT_ID}"
 printf 'App ID: %s\n' "$(jq -r '.result.sdkConfig.appId' <<<"${SDK_CONFIG}")"
-printf 'API key: %s\n' "$(jq -r '.result.sdkConfig.apiKey' <<<"${SDK_CONFIG}")"
+printf 'API key: %s\n' "${API_KEY}"

--- a/deploy/gcp/setup-firebase.sh
+++ b/deploy/gcp/setup-firebase.sh
@@ -9,6 +9,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
 command -v firebase >/dev/null || { printf 'firebase-tools is required\n' >&2; exit 1; }
 
+BILLING_ENABLED="$(gcloud billing projects describe "${GCP_PROJECT_ID}" --format='value(billingEnabled)' 2>/dev/null || true)"
+if [[ "${BILLING_ENABLED}" == "True" && "${ALLOW_BILLED_PROJECT:-0}" != "1" ]]; then
+  printf 'project %s has billing enabled; use an unbilled project for Spark or set ALLOW_BILLED_PROJECT=1\n' "${GCP_PROJECT_ID}" >&2
+  exit 1
+fi
+
 gcloud config set project "${GCP_PROJECT_ID}"
 gcloud services enable \
   firebase.googleapis.com \

--- a/deploy/gcp/setup-github-actions.sh
+++ b/deploy/gcp/setup-github-actions.sh
@@ -20,6 +20,16 @@ case "${DEPLOY_STAGE}" in
   *) printf 'DEPLOY_STAGE must be development, staging, or production\n' >&2; exit 1 ;;
 esac
 
+if [[ "${DEPLOY_STAGE}" == "production" ]]; then
+  FIREBASE_APP_DISPLAY_NAME="${FIREBASE_APP_DISPLAY_NAME:-Yokai CLI}"
+else
+  FIREBASE_APP_DISPLAY_NAME="${FIREBASE_APP_DISPLAY_NAME:-Yokai CLI ${DEPLOY_STAGE}}"
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=setup-common.sh
+source "${REPO_ROOT}/deploy/gcp/setup-common.sh"
+
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-spencerbull/Yokai}"
 GITHUB_PRODUCTION_REVIEWER="${GITHUB_PRODUCTION_REVIEWER:-spencerbull}"
 POOL_ID="${WIF_POOL_ID:-github-actions}"
@@ -42,7 +52,7 @@ ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && asser
 
 if [[ "${DEPLOY_STAGE}" == "production" ]]; then
   REVIEWER_ID="$(gh api "users/${GITHUB_PRODUCTION_REVIEWER}" --jq '.id')"
-  ENVIRONMENT_CONFIG="$(jq -n --argjson reviewer "${REVIEWER_ID}" '{wait_timer: 0, prevent_self_review: false, reviewers: [{type: "User", id: $reviewer}], deployment_branch_policy: {protected_branches: false, custom_branch_policies: true}}')"
+  ENVIRONMENT_CONFIG="$(jq -n --argjson reviewer "${REVIEWER_ID}" '{wait_timer: 0, prevent_self_review: false, can_admins_bypass: false, reviewers: [{type: "User", id: $reviewer}], deployment_branch_policy: {protected_branches: false, custom_branch_policies: true}}')"
 else
   ENVIRONMENT_CONFIG='{"wait_timer":0,"prevent_self_review":false,"reviewers":[],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
 fi
@@ -119,7 +129,13 @@ gcloud iam service-accounts remove-iam-policy-binding "${SERVICE_ACCOUNT}" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPOSITORY}" >/dev/null 2>&1 || true
 
-APP_ID="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json | jq -r '.result[0].appId')"
+APPS="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json)"
+APP_MATCH_COUNT="$(firebase_app_match_count "${APPS}" "${FIREBASE_APP_DISPLAY_NAME}")"
+if [[ "${APP_MATCH_COUNT}" != "1" ]]; then
+  printf 'expected exactly one Firebase web app named %q, found %s; run setup-firebase.sh first\n' "${FIREBASE_APP_DISPLAY_NAME}" "${APP_MATCH_COUNT}" >&2
+  exit 1
+fi
+APP_ID="$(firebase_app_id "${APPS}" "${FIREBASE_APP_DISPLAY_NAME}")"
 SDK_CONFIG="$(firebase apps:sdkconfig WEB "${APP_ID}" --project "${GCP_PROJECT_ID}" --json)"
 API_KEY="$(jq -r '.result.sdkConfig.apiKey' <<<"${SDK_CONFIG}")"
 PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"

--- a/deploy/gcp/setup-github-actions.sh
+++ b/deploy/gcp/setup-github-actions.sh
@@ -2,32 +2,60 @@
 set -euo pipefail
 
 : "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID to the Firebase project ID}"
+: "${DEPLOY_STAGE:?Set DEPLOY_STAGE to development, staging, or production}"
+
+case "${DEPLOY_STAGE}" in
+  development)
+    DEPLOY_ENVIRONMENT="firebase-development"
+    DEPLOY_BRANCH="develop"
+    ;;
+  staging)
+    DEPLOY_ENVIRONMENT="firebase-staging"
+    DEPLOY_BRANCH="staging"
+    ;;
+  production)
+    DEPLOY_ENVIRONMENT="firebase-production"
+    DEPLOY_BRANCH="main"
+    ;;
+  *) printf 'DEPLOY_STAGE must be development, staging, or production\n' >&2; exit 1 ;;
+esac
 
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-spencerbull/Yokai}"
+GITHUB_PRODUCTION_REVIEWER="${GITHUB_PRODUCTION_REVIEWER:-spencerbull}"
 POOL_ID="${WIF_POOL_ID:-github-actions}"
 PROVIDER_ID="${WIF_PROVIDER_ID:-yokai-repository}"
 SERVICE_ACCOUNT_ID="${DEPLOY_SERVICE_ACCOUNT_ID:-github-firestore-deployer}"
 SERVICE_ACCOUNT="${SERVICE_ACCOUNT_ID}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
 CUSTOM_ROLE_ID="${DEPLOY_CUSTOM_ROLE_ID:-firebaseRulesDeployer}"
 CUSTOM_ROLE="projects/${GCP_PROJECT_ID}/roles/${CUSTOM_ROLE_ID}"
-DEPLOY_ENVIRONMENT="firebase-production"
 
 command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
 command -v gh >/dev/null || { printf 'gh is required\n' >&2; exit 1; }
+command -v firebase >/dev/null || { printf 'firebase-tools is required\n' >&2; exit 1; }
+command -v jq >/dev/null || { printf 'jq is required\n' >&2; exit 1; }
 
 PROJECT_NUMBER="$(gcloud projects describe "${GCP_PROJECT_ID}" --format='value(projectNumber)')"
 GITHUB_REPOSITORY_ID="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.id')"
-WORKFLOW_REF="${GITHUB_REPOSITORY}/.github/workflows/deploy-firebase.yml@refs/heads/main"
+WORKFLOW_REF="${GITHUB_REPOSITORY}/.github/workflows/deploy-firebase.yml@refs/heads/${DEPLOY_BRANCH}"
 ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.ref=assertion.ref,attribute.environment=assertion.environment,attribute.workflow_ref=assertion.workflow_ref"
-ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.ref=='refs/heads/main' && assertion.environment=='${DEPLOY_ENVIRONMENT}' && assertion.workflow_ref=='${WORKFLOW_REF}'"
+ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.ref=='refs/heads/${DEPLOY_BRANCH}' && assertion.environment=='${DEPLOY_ENVIRONMENT}' && assertion.workflow_ref=='${WORKFLOW_REF}'"
 
-gh api -X PUT "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}" --input - >/dev/null <<'JSON'
-{"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
-JSON
-if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies" --jq 'any(.branch_policies[]; .name == "main" and .type == "branch")')" != "true" ]]; then
-  gh api -X POST "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies" --input - >/dev/null <<'JSON'
-{"name":"main"}
-JSON
+if [[ "${DEPLOY_STAGE}" == "production" ]]; then
+  REVIEWER_ID="$(gh api "users/${GITHUB_PRODUCTION_REVIEWER}" --jq '.id')"
+  ENVIRONMENT_CONFIG="$(jq -n --argjson reviewer "${REVIEWER_ID}" '{wait_timer: 0, prevent_self_review: false, reviewers: [{type: "User", id: $reviewer}], deployment_branch_policy: {protected_branches: false, custom_branch_policies: true}}')"
+else
+  ENVIRONMENT_CONFIG='{"wait_timer":0,"prevent_self_review":false,"reviewers":[],"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+fi
+gh api -X PUT "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}" --input - >/dev/null <<<"${ENVIRONMENT_CONFIG}"
+
+POLICIES="$(gh api "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies")"
+while IFS= read -r policy_id; do
+  [[ -z "${policy_id}" ]] && continue
+  gh api -X DELETE "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies/${policy_id}" >/dev/null
+done < <(jq -r --arg branch "${DEPLOY_BRANCH}" '.branch_policies[] | select(.name != $branch or .type != "branch") | .id' <<<"${POLICIES}")
+if ! jq -e --arg branch "${DEPLOY_BRANCH}" '.branch_policies[] | select(.name == $branch and .type == "branch")' <<<"${POLICIES}" >/dev/null; then
+  jq -n --arg branch "${DEPLOY_BRANCH}" '{name: $branch}' | \
+    gh api -X POST "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies" --input - >/dev/null
 fi
 
 gcloud services enable iamcredentials.googleapis.com sts.googleapis.com --project "${GCP_PROJECT_ID}"
@@ -44,7 +72,7 @@ if ! gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" --wo
     --workload-identity-pool="${POOL_ID}" \
     --location=global \
     --project "${GCP_PROJECT_ID}" \
-    --display-name="${GITHUB_REPOSITORY}" \
+    --display-name="${GITHUB_REPOSITORY} ${DEPLOY_STAGE}" \
     --issuer-uri="https://token.actions.githubusercontent.com" \
     --attribute-mapping="${ATTRIBUTE_MAPPING}" \
     --attribute-condition="${ATTRIBUTE_CONDITION}"
@@ -60,7 +88,7 @@ gcloud iam workload-identity-pools providers update-oidc "${PROVIDER_ID}" \
 if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
   gcloud iam service-accounts create "${SERVICE_ACCOUNT_ID}" \
     --project "${GCP_PROJECT_ID}" \
-    --display-name="GitHub Firestore Rules Deployer"
+    --display-name="GitHub Firestore Rules Deployer (${DEPLOY_STAGE})"
 fi
 
 ROLE_PERMISSIONS="firebase.projects.get,firebaserules.releases.create,firebaserules.releases.get,firebaserules.releases.list,firebaserules.releases.update,firebaserules.rulesets.create,firebaserules.rulesets.get,firebaserules.rulesets.list,firebaserules.rulesets.test,resourcemanager.projects.get,serviceusage.services.get,serviceusage.services.use"
@@ -91,11 +119,17 @@ gcloud iam service-accounts remove-iam-policy-binding "${SERVICE_ACCOUNT}" \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPOSITORY}" >/dev/null 2>&1 || true
 
+APP_ID="$(firebase apps:list WEB --project "${GCP_PROJECT_ID}" --json | jq -r '.result[0].appId')"
+SDK_CONFIG="$(firebase apps:sdkconfig WEB "${APP_ID}" --project "${GCP_PROJECT_ID}" --json)"
+API_KEY="$(jq -r '.result.sdkConfig.apiKey' <<<"${SDK_CONFIG}")"
 PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
-gh variable set FIREBASE_PROJECT_ID --repo "${GITHUB_REPOSITORY}" --body "${GCP_PROJECT_ID}"
-gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER --repo "${GITHUB_REPOSITORY}" --body "${PROVIDER}"
-gh variable set GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT --repo "${GITHUB_REPOSITORY}" --body "${SERVICE_ACCOUNT}"
+gh variable set FIREBASE_PROJECT_ID --repo "${GITHUB_REPOSITORY}" --env "${DEPLOY_ENVIRONMENT}" --body "${GCP_PROJECT_ID}"
+gh variable set FIREBASE_APP_ID --repo "${GITHUB_REPOSITORY}" --env "${DEPLOY_ENVIRONMENT}" --body "${APP_ID}"
+gh variable set FIREBASE_API_KEY --repo "${GITHUB_REPOSITORY}" --env "${DEPLOY_ENVIRONMENT}" --body "${API_KEY}"
+gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER --repo "${GITHUB_REPOSITORY}" --env "${DEPLOY_ENVIRONMENT}" --body "${PROVIDER}"
+gh variable set GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT --repo "${GITHUB_REPOSITORY}" --env "${DEPLOY_ENVIRONMENT}" --body "${SERVICE_ACCOUNT}"
 
-printf 'Configured keyless Firebase deployment for %s\n' "${GITHUB_REPOSITORY}"
+printf 'Configured keyless %s Firebase deployment for %s\n' "${DEPLOY_STAGE}" "${GITHUB_REPOSITORY}"
+printf 'GitHub environment: %s (%s only)\n' "${DEPLOY_ENVIRONMENT}" "${DEPLOY_BRANCH}"
 printf 'Workload identity provider: %s\n' "${PROVIDER}"
 printf 'Service account: %s\n' "${SERVICE_ACCOUNT}"

--- a/deploy/gcp/setup-github-actions.sh
+++ b/deploy/gcp/setup-github-actions.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID to the Firebase project ID}"
+
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-spencerbull/Yokai}"
+POOL_ID="${WIF_POOL_ID:-github-actions}"
+PROVIDER_ID="${WIF_PROVIDER_ID:-yokai-repository}"
+SERVICE_ACCOUNT_ID="${DEPLOY_SERVICE_ACCOUNT_ID:-github-firestore-deployer}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT_ID}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
+command -v gh >/dev/null || { printf 'gh is required\n' >&2; exit 1; }
+
+PROJECT_NUMBER="$(gcloud projects describe "${GCP_PROJECT_ID}" --format='value(projectNumber)')"
+gcloud services enable iamcredentials.googleapis.com sts.googleapis.com --project "${GCP_PROJECT_ID}"
+
+if ! gcloud iam workload-identity-pools describe "${POOL_ID}" --location=global --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools create "${POOL_ID}" \
+    --location=global \
+    --project "${GCP_PROJECT_ID}" \
+    --display-name="GitHub Actions"
+fi
+
+if ! gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" --workload-identity-pool="${POOL_ID}" --location=global --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools providers create-oidc "${PROVIDER_ID}" \
+    --workload-identity-pool="${POOL_ID}" \
+    --location=global \
+    --project "${GCP_PROJECT_ID}" \
+    --display-name="${GITHUB_REPOSITORY}" \
+    --issuer-uri="https://token.actions.githubusercontent.com" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
+    --attribute-condition="assertion.repository=='${GITHUB_REPOSITORY}' && assertion.ref=='refs/heads/main'"
+fi
+
+gcloud iam workload-identity-pools providers update-oidc "${PROVIDER_ID}" \
+  --workload-identity-pool="${POOL_ID}" \
+  --location=global \
+  --project "${GCP_PROJECT_ID}" \
+  --attribute-condition="assertion.repository=='${GITHUB_REPOSITORY}' && assertion.ref=='refs/heads/main'" >/dev/null
+
+if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "${SERVICE_ACCOUNT_ID}" \
+    --project "${GCP_PROJECT_ID}" \
+    --display-name="GitHub Firestore Rules Deployer"
+fi
+
+for role in roles/firebaserules.admin roles/firebase.viewer roles/serviceusage.serviceUsageConsumer; do
+  gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+    --member="serviceAccount:${SERVICE_ACCOUNT}" \
+    --role="${role}" \
+    --condition=None >/dev/null
+done
+
+gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT}" \
+  --project "${GCP_PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPOSITORY}" >/dev/null
+
+PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+gh variable set FIREBASE_PROJECT_ID --repo "${GITHUB_REPOSITORY}" --body "${GCP_PROJECT_ID}"
+gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER --repo "${GITHUB_REPOSITORY}" --body "${PROVIDER}"
+gh variable set GCP_FIREBASE_DEPLOY_SERVICE_ACCOUNT --repo "${GITHUB_REPOSITORY}" --body "${SERVICE_ACCOUNT}"
+
+printf 'Configured keyless Firebase deployment for %s\n' "${GITHUB_REPOSITORY}"
+printf 'Workload identity provider: %s\n' "${PROVIDER}"
+printf 'Service account: %s\n' "${SERVICE_ACCOUNT}"

--- a/deploy/gcp/setup-github-actions.sh
+++ b/deploy/gcp/setup-github-actions.sh
@@ -8,11 +8,28 @@ POOL_ID="${WIF_POOL_ID:-github-actions}"
 PROVIDER_ID="${WIF_PROVIDER_ID:-yokai-repository}"
 SERVICE_ACCOUNT_ID="${DEPLOY_SERVICE_ACCOUNT_ID:-github-firestore-deployer}"
 SERVICE_ACCOUNT="${SERVICE_ACCOUNT_ID}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+CUSTOM_ROLE_ID="${DEPLOY_CUSTOM_ROLE_ID:-firebaseRulesDeployer}"
+CUSTOM_ROLE="projects/${GCP_PROJECT_ID}/roles/${CUSTOM_ROLE_ID}"
+DEPLOY_ENVIRONMENT="firebase-production"
 
 command -v gcloud >/dev/null || { printf 'gcloud is required\n' >&2; exit 1; }
 command -v gh >/dev/null || { printf 'gh is required\n' >&2; exit 1; }
 
 PROJECT_NUMBER="$(gcloud projects describe "${GCP_PROJECT_ID}" --format='value(projectNumber)')"
+GITHUB_REPOSITORY_ID="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.id')"
+WORKFLOW_REF="${GITHUB_REPOSITORY}/.github/workflows/deploy-firebase.yml@refs/heads/main"
+ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.ref=assertion.ref,attribute.environment=assertion.environment,attribute.workflow_ref=assertion.workflow_ref"
+ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.ref=='refs/heads/main' && assertion.environment=='${DEPLOY_ENVIRONMENT}' && assertion.workflow_ref=='${WORKFLOW_REF}'"
+
+gh api -X PUT "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}" --input - >/dev/null <<'JSON'
+{"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}
+JSON
+if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies" --jq 'any(.branch_policies[]; .name == "main" and .type == "branch")')" != "true" ]]; then
+  gh api -X POST "repos/${GITHUB_REPOSITORY}/environments/${DEPLOY_ENVIRONMENT}/deployment-branch-policies" --input - >/dev/null <<'JSON'
+{"name":"main"}
+JSON
+fi
+
 gcloud services enable iamcredentials.googleapis.com sts.googleapis.com --project "${GCP_PROJECT_ID}"
 
 if ! gcloud iam workload-identity-pools describe "${POOL_ID}" --location=global --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
@@ -29,15 +46,16 @@ if ! gcloud iam workload-identity-pools providers describe "${PROVIDER_ID}" --wo
     --project "${GCP_PROJECT_ID}" \
     --display-name="${GITHUB_REPOSITORY}" \
     --issuer-uri="https://token.actions.githubusercontent.com" \
-    --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref" \
-    --attribute-condition="assertion.repository=='${GITHUB_REPOSITORY}' && assertion.ref=='refs/heads/main'"
+    --attribute-mapping="${ATTRIBUTE_MAPPING}" \
+    --attribute-condition="${ATTRIBUTE_CONDITION}"
 fi
 
 gcloud iam workload-identity-pools providers update-oidc "${PROVIDER_ID}" \
   --workload-identity-pool="${POOL_ID}" \
   --location=global \
   --project "${GCP_PROJECT_ID}" \
-  --attribute-condition="assertion.repository=='${GITHUB_REPOSITORY}' && assertion.ref=='refs/heads/main'" >/dev/null
+  --attribute-mapping="${ATTRIBUTE_MAPPING}" \
+  --attribute-condition="${ATTRIBUTE_CONDITION}" >/dev/null
 
 if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
   gcloud iam service-accounts create "${SERVICE_ACCOUNT_ID}" \
@@ -45,17 +63,33 @@ if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT}" --project "${GCP_
     --display-name="GitHub Firestore Rules Deployer"
 fi
 
-for role in roles/firebaserules.admin roles/firebase.viewer roles/serviceusage.serviceUsageConsumer; do
-  gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+ROLE_PERMISSIONS="firebase.projects.get,firebaserules.releases.create,firebaserules.releases.get,firebaserules.releases.list,firebaserules.releases.update,firebaserules.rulesets.create,firebaserules.rulesets.get,firebaserules.rulesets.list,firebaserules.rulesets.test,resourcemanager.projects.get,serviceusage.services.get,serviceusage.services.use"
+if gcloud iam roles describe "${CUSTOM_ROLE_ID}" --project "${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud iam roles update "${CUSTOM_ROLE_ID}" --project "${GCP_PROJECT_ID}" --permissions="${ROLE_PERMISSIONS}" --stage=GA >/dev/null
+else
+  gcloud iam roles create "${CUSTOM_ROLE_ID}" --project "${GCP_PROJECT_ID}" --title="Firebase Rules Deployer" --description="Deploy Firestore Security Rules from GitHub Actions" --permissions="${ROLE_PERMISSIONS}" --stage=GA >/dev/null
+fi
+gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+  --member="serviceAccount:${SERVICE_ACCOUNT}" \
+  --role="${CUSTOM_ROLE}" \
+  --condition=None >/dev/null
+
+for legacy_role in roles/firebaserules.admin roles/firebase.viewer roles/serviceusage.serviceUsageConsumer; do
+  gcloud projects remove-iam-policy-binding "${GCP_PROJECT_ID}" \
     --member="serviceAccount:${SERVICE_ACCOUNT}" \
-    --role="${role}" \
-    --condition=None >/dev/null
+    --role="${legacy_role}" \
+    --condition=None >/dev/null 2>&1 || true
 done
 
 gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT}" \
   --project "${GCP_PROJECT_ID}" \
   --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPOSITORY}" >/dev/null
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}" >/dev/null
+
+gcloud iam service-accounts remove-iam-policy-binding "${SERVICE_ACCOUNT}" \
+  --project "${GCP_PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository/${GITHUB_REPOSITORY}" >/dev/null 2>&1 || true
 
 PROVIDER="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
 gh variable set FIREBASE_PROJECT_ID --repo "${GITHUB_REPOSITORY}" --body "${GCP_PROJECT_ID}"

--- a/deploy/github/setup-branch-governance.sh
+++ b/deploy/github/setup-branch-governance.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-spencerbull/Yokai}"
+REQUIRED_APPROVER="${REQUIRED_APPROVER:-spencerbull}"
+RULESET_NAME="${RULESET_NAME:-Protected long-lived branches}"
+
+command -v gh >/dev/null || { printf 'gh is required\n' >&2; exit 1; }
+command -v jq >/dev/null || { printf 'jq is required\n' >&2; exit 1; }
+
+APPROVER_ID="$(gh api "users/${REQUIRED_APPROVER}" --jq '.id')"
+PAYLOAD="$(jq -n \
+  --arg name "${RULESET_NAME}" \
+  --argjson approver "${APPROVER_ID}" \
+  '{
+    name: $name,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [
+      {actor_id: $approver, actor_type: "User", bypass_mode: "pull_request"}
+    ],
+    conditions: {
+      ref_name: {
+        include: ["refs/heads/develop", "refs/heads/staging", "refs/heads/main"],
+        exclude: []
+      }
+    },
+    rules: [
+      {type: "deletion"},
+      {type: "non_fast_forward"},
+      {
+        type: "pull_request",
+        parameters: {
+          allowed_merge_methods: ["merge", "squash", "rebase"],
+          dismiss_stale_reviews_on_push: true,
+          require_code_owner_review: true,
+          require_last_push_approval: false,
+          required_approving_review_count: 1,
+          required_review_thread_resolution: true
+        }
+      },
+      {
+        type: "required_status_checks",
+        parameters: {
+          do_not_enforce_on_create: false,
+          strict_required_status_checks_policy: true,
+          required_status_checks: [
+            {context: "build (1.25)"},
+            {context: "lint"},
+            {context: "tui"},
+            {context: "release-package"},
+            {context: "firestore-rules"}
+          ]
+        }
+      }
+    ]
+  }')"
+
+RULESET_ID="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --paginate | jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id' | head -1)"
+if [[ -n "${RULESET_ID}" ]]; then
+  gh api -X PUT "repos/${GITHUB_REPOSITORY}/rulesets/${RULESET_ID}" --input - >/dev/null <<<"${PAYLOAD}"
+else
+  RULESET_ID="$(gh api -X POST "repos/${GITHUB_REPOSITORY}/rulesets" --input - --jq '.id' <<<"${PAYLOAD}")"
+fi
+
+printf 'Configured ruleset %s (%s) for develop, staging, and main.\n' "${RULESET_NAME}" "${RULESET_ID}"
+printf 'Pull requests require passing checks and approval from code owner @%s.\n' "${REQUIRED_APPROVER}"
+printf '@%s may bypass approval only while merging a pull request; direct pushes remain blocked.\n' "${REQUIRED_APPROVER}"

--- a/deploy/github/setup-branch-governance.sh
+++ b/deploy/github/setup-branch-governance.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-spencerbull/Yokai}"
 REQUIRED_APPROVER="${REQUIRED_APPROVER:-spencerbull}"
 RULESET_NAME="${RULESET_NAME:-Protected long-lived branches}"
+APPROVAL_RULESET_NAME="${APPROVAL_RULESET_NAME:-Long-lived branch approval}"
 
 command -v gh >/dev/null || { printf 'gh is required\n' >&2; exit 1; }
 command -v jq >/dev/null || { printf 'jq is required\n' >&2; exit 1; }
@@ -11,14 +12,11 @@ command -v jq >/dev/null || { printf 'jq is required\n' >&2; exit 1; }
 APPROVER_ID="$(gh api "users/${REQUIRED_APPROVER}" --jq '.id')"
 PAYLOAD="$(jq -n \
   --arg name "${RULESET_NAME}" \
-  --argjson approver "${APPROVER_ID}" \
   '{
     name: $name,
     target: "branch",
     enforcement: "active",
-    bypass_actors: [
-      {actor_id: $approver, actor_type: "User", bypass_mode: "pull_request"}
-    ],
+    bypass_actors: [],
     conditions: {
       ref_name: {
         include: ["refs/heads/develop", "refs/heads/staging", "refs/heads/main"],
@@ -33,9 +31,9 @@ PAYLOAD="$(jq -n \
         parameters: {
           allowed_merge_methods: ["merge", "squash", "rebase"],
           dismiss_stale_reviews_on_push: true,
-          require_code_owner_review: true,
+          require_code_owner_review: false,
           require_last_push_approval: false,
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
           required_review_thread_resolution: true
         }
       },
@@ -56,6 +54,37 @@ PAYLOAD="$(jq -n \
     ]
   }')"
 
+APPROVAL_PAYLOAD="$(jq -n \
+  --arg name "${APPROVAL_RULESET_NAME}" \
+  --argjson approver "${APPROVER_ID}" \
+  '{
+    name: $name,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [
+      {actor_id: $approver, actor_type: "User", bypass_mode: "pull_request"}
+    ],
+    conditions: {
+      ref_name: {
+        include: ["refs/heads/develop", "refs/heads/staging", "refs/heads/main"],
+        exclude: []
+      }
+    },
+    rules: [
+      {
+        type: "pull_request",
+        parameters: {
+          allowed_merge_methods: ["merge", "squash", "rebase"],
+          dismiss_stale_reviews_on_push: true,
+          require_code_owner_review: true,
+          require_last_push_approval: false,
+          required_approving_review_count: 1,
+          required_review_thread_resolution: false
+        }
+      }
+    ]
+  }')"
+
 RULESET_ID="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --paginate | jq -r --arg name "${RULESET_NAME}" '.[] | select(.name == $name) | .id' | head -1)"
 if [[ -n "${RULESET_ID}" ]]; then
   gh api -X PUT "repos/${GITHUB_REPOSITORY}/rulesets/${RULESET_ID}" --input - >/dev/null <<<"${PAYLOAD}"
@@ -63,6 +92,14 @@ else
   RULESET_ID="$(gh api -X POST "repos/${GITHUB_REPOSITORY}/rulesets" --input - --jq '.id' <<<"${PAYLOAD}")"
 fi
 
+APPROVAL_RULESET_ID="$(gh api "repos/${GITHUB_REPOSITORY}/rulesets" --paginate | jq -r --arg name "${APPROVAL_RULESET_NAME}" '.[] | select(.name == $name) | .id' | head -1)"
+if [[ -n "${APPROVAL_RULESET_ID}" ]]; then
+  gh api -X PUT "repos/${GITHUB_REPOSITORY}/rulesets/${APPROVAL_RULESET_ID}" --input - >/dev/null <<<"${APPROVAL_PAYLOAD}"
+else
+  APPROVAL_RULESET_ID="$(gh api -X POST "repos/${GITHUB_REPOSITORY}/rulesets" --input - --jq '.id' <<<"${APPROVAL_PAYLOAD}")"
+fi
+
 printf 'Configured ruleset %s (%s) for develop, staging, and main.\n' "${RULESET_NAME}" "${RULESET_ID}"
-printf 'Pull requests require passing checks and approval from code owner @%s.\n' "${REQUIRED_APPROVER}"
-printf '@%s may bypass approval only while merging a pull request; direct pushes remain blocked.\n' "${REQUIRED_APPROVER}"
+printf 'Configured approval ruleset %s (%s).\n' "${APPROVAL_RULESET_NAME}" "${APPROVAL_RULESET_ID}"
+printf 'Pull requests require passing checks, resolved threads, and approval from code owner @%s.\n' "${REQUIRED_APPROVER}"
+printf '@%s may bypass only the approval ruleset while merging a pull request.\n' "${REQUIRED_APPROVER}"

--- a/docs/cloud-device-config.md
+++ b/docs/cloud-device-config.md
@@ -37,6 +37,12 @@ currently includes social sign-in and a Firestore quota of 1 GiB stored data,
 outbound transfer/month. If a Spark quota is exhausted, the product is paused
 instead of generating an overage bill.
 
+Those quotas are shared by the whole project, so an authenticated user can still
+exhaust the free allowance and temporarily deny service to everyone. Keep the
+OAuth app in **Testing** with an explicit test-user allowlist until usage is
+understood. Before making sign-in public, place a rate-limited service in front
+of Firestore or accept this availability tradeoff.
+
 This deliberately avoids Cloud Run, Cloud Build, Artifact Registry, Secret
 Manager, and a privileged runtime service account. It also leaves only one
 deployed security boundary: Firestore Security Rules.
@@ -76,23 +82,41 @@ export GCP_PROJECT_ID="your-project-id"
 ./deploy/gcp/setup-github-actions.sh
 ```
 
-The setup creates a dedicated service account, a workload identity provider
-restricted to the `spencerbull/Yokai` repository's `main` branch, and the required
-GitHub repository variables. It creates no service-account key or GitHub secret.
-Pull requests run the rules against the Firestore emulator; changes merged to
-`main` rerun those tests and deploy the rules only after they pass.
+The setup creates a dedicated service account with a narrow custom rules-deployer
+role and a workload identity provider restricted to this repository's immutable
+GitHub ID, the `main` branch, the `firebase-production` environment, and this
+specific deployment workflow. It also creates the required GitHub repository
+variables. It creates no service-account key or GitHub secret. Pull requests run
+the rules against the Firestore emulator; changes merged to `main` rerun those
+tests and deploy the rules only after they pass.
 
 Next, in **Google Auth Platform** for the same project:
 
 1. Configure the branding/audience and add test users while the app is in testing.
 2. Enable Google as a Firebase Authentication sign-in provider.
 3. Create an OAuth client with application type **Desktop app**.
+4. Configure release builds with the OAuth client values:
+
+```bash
+gh variable set YOKAI_GOOGLE_CLIENT_ID --body "000000000000-example.apps.googleusercontent.com"
+gh variable set YOKAI_GOOGLE_CLIENT_SECRET --body "desktop-client-secret"
+```
 
 Desktop OAuth client secrets identify an installed app but cannot be kept
 confidential. Yokai uses the secret only for the authorization-code exchange and
 does not save it after login.
 
 ## Sign in and use
+
+Official releases include the public Firebase project configuration and the
+desktop OAuth client configured by the release workflow, so sign-in is normally:
+
+```bash
+yokai cloud login
+```
+
+For a self-hosted backend or a locally built binary, supply the configuration
+explicitly:
 
 ```bash
 yokai cloud login \
@@ -115,10 +139,12 @@ yokai cloud logout
 yokai cloud delete --yes
 ```
 
-Interactive commands read the encryption passphrase without echo. Use a long,
+Interactive commands read the encryption passphrase without echo. `cloud save`
+asks for it twice before replacing the existing cloud snapshot, reducing the
+chance that a typo makes the last usable snapshot inaccessible. Use a long,
 unique passphrase and keep it in a password manager. Automation can set
-`YOKAI_CLOUD_PASSPHRASE`, but a process environment may be visible to other
-processes owned by the same operating-system user.
+`YOKAI_CLOUD_PASSPHRASE` to bypass the prompt, but a process environment may be
+visible to other processes owned by the same operating-system user.
 
 `yokai cloud load` replaces only devices and writes a timestamped local backup.
 If the local daemon is running, the CLI asks it to reload the new device list.
@@ -131,5 +157,7 @@ If the local daemon is running, the CLI asks it to reload the new device list.
 - Do not grant application users IAM roles in the Google Cloud project.
 - Do not enable phone authentication, Cloud Functions, or other paid products.
 - Review Firebase Authentication users and Firestore usage periodically.
+- Treat an unexpected usage spike as abuse: disable the Google sign-in provider
+  or remove untrusted test users until the source is understood.
 - Rotate the desktop OAuth client if it is abused. Existing Firebase refresh
   sessions can be revoked from Firebase Authentication.

--- a/docs/cloud-device-config.md
+++ b/docs/cloud-device-config.md
@@ -1,0 +1,135 @@
+# Cloud device configuration
+
+Yokai can save and restore the `devices` section of `~/.config/yokai/config.json`
+with Firebase Authentication and Cloud Firestore. Other local settings, deploy
+history, and the Hugging Face token are not synchronized.
+
+## Architecture
+
+```text
+Yokai CLI
+  ├─ Google desktop OAuth (openid + email only)
+  ├─ Exchange Google ID token for a Firebase user session
+  ├─ Argon2id passphrase derivation + AES-256-GCM encryption
+  └─ Firestore REST request containing ciphertext
+          │
+          ▼
+Firestore device_configs/{Firebase UID}
+  └─ Security Rules allow only request.auth.uid == document UID
+```
+
+The Google account controls which Firestore document Firebase can access. A
+separate encryption passphrase never leaves the machine and prevents Firebase,
+project operators, or a database export from reading device hosts, SSH details,
+or agent tokens. Losing the passphrase makes the cloud copy unrecoverable.
+
+Firebase refresh credentials are stored locally at
+`~/.config/yokai/cloud-auth.json` with mode `0600`. The initial Google grant only
+requests `openid` and `email`; it does not grant Yokai access to Google Drive,
+Gmail, or the user's Google Cloud resources. The Google OAuth refresh token and
+desktop client secret are not persisted by Yokai.
+
+## Why Firebase Spark
+
+The no-cost Spark plan requires no billing account or payment method. Google
+currently includes social sign-in and a Firestore quota of 1 GiB stored data,
+50,000 document reads/day, 20,000 writes/day, 20,000 deletes/day, and 10 GiB
+outbound transfer/month. If a Spark quota is exhausted, the product is paused
+instead of generating an overage bill.
+
+This deliberately avoids Cloud Run, Cloud Build, Artifact Registry, Secret
+Manager, and a privileged runtime service account. It also leaves only one
+deployed security boundary: Firestore Security Rules.
+
+Current references:
+
+- [Firebase pricing plans](https://firebase.google.com/docs/projects/billing/firebase-pricing-plans)
+- [Firestore free quota](https://firebase.google.com/docs/firestore/pricing)
+- [Firebase API keys are public identifiers](https://firebase.google.com/docs/projects/api-keys)
+- [Google OAuth for desktop apps](https://developers.google.com/identity/protocols/oauth2/native-app)
+
+## Set up the Google backend
+
+Prerequisites:
+
+1. Install and authenticate the Google Cloud and Firebase CLIs.
+2. Use a Google Cloud project without a billing account to stay on Firebase's
+   Spark plan.
+3. Run the setup script from the repository root:
+
+```bash
+export GCP_PROJECT_ID="your-project-id"
+./deploy/gcp/setup-firebase.sh
+```
+
+The script adds Firebase, creates the single free Firestore database in
+`us-central1`, creates a Firebase Web App if necessary, and deploys
+`firestore.rules`. It prints the Firebase project configuration containing the
+public API key.
+
+### Continuous deployment
+
+Configure keyless GitHub Actions access once:
+
+```bash
+export GCP_PROJECT_ID="your-project-id"
+./deploy/gcp/setup-github-actions.sh
+```
+
+The setup creates a dedicated service account, a workload identity provider
+restricted to the `spencerbull/Yokai` repository's `main` branch, and the required
+GitHub repository variables. It creates no service-account key or GitHub secret.
+Pull requests run the rules against the Firestore emulator; changes merged to
+`main` rerun those tests and deploy the rules only after they pass.
+
+Next, in **Google Auth Platform** for the same project:
+
+1. Configure the branding/audience and add test users while the app is in testing.
+2. Enable Google as a Firebase Authentication sign-in provider.
+3. Create an OAuth client with application type **Desktop app**.
+
+Desktop OAuth client secrets identify an installed app but cannot be kept
+confidential. Yokai uses the secret only for the authorization-code exchange and
+does not save it after login.
+
+## Sign in and use
+
+```bash
+yokai cloud login \
+  --project-id "your-project-id" \
+  --api-key "firebase-public-api-key" \
+  --client-id "000000000000-example.apps.googleusercontent.com" \
+  --client-secret "desktop-client-secret"
+
+# Encrypt and upload only device records
+yokai cloud save
+
+# Restore device records; existing config is backed up first
+yokai cloud load
+
+# Check or remove local login state
+yokai cloud status
+yokai cloud logout
+
+# Permanently delete the server-side ciphertext
+yokai cloud delete --yes
+```
+
+Interactive commands read the encryption passphrase without echo. Use a long,
+unique passphrase and keep it in a password manager. Automation can set
+`YOKAI_CLOUD_PASSPHRASE`, but a process environment may be visible to other
+processes owned by the same operating-system user.
+
+`yokai cloud load` replaces only devices and writes a timestamped local backup.
+If the local daemon is running, the CLI asks it to reload the new device list.
+
+## Security operations
+
+- Deploy the checked-in Firestore rules before enabling sign-in.
+- Keep the Firebase-provisioned API key restricted to Firebase APIs. It is a
+  public project identifier, not authorization; Security Rules authorize data.
+- Do not grant application users IAM roles in the Google Cloud project.
+- Do not enable phone authentication, Cloud Functions, or other paid products.
+- Review Firebase Authentication users and Firestore usage periodically.
+- Rotate the desktop OAuth client if it is abused. Existing Firebase refresh
+  sessions can be revoked from Firebase Authentication.

--- a/docs/cloud-device-config.md
+++ b/docs/cloud-device-config.md
@@ -54,43 +54,81 @@ Current references:
 - [Firebase API keys are public identifiers](https://firebase.google.com/docs/projects/api-keys)
 - [Google OAuth for desktop apps](https://developers.google.com/identity/protocols/oauth2/native-app)
 
-## Set up the Google backend
+## Environment isolation
+
+Yokai uses three persistent, unbilled Firebase Spark projects. Data, users,
+quotas, API keys, deployment identities, and security-rule releases are isolated
+between them.
+
+| Git branch | GitHub environment | Firebase project | Purpose |
+|---|---|---|---|
+| `develop` | `firebase-development` | `yokai-config-dev-260709-5820` | Integrated development |
+| `staging` | `firebase-staging` | `yokai-config-stg-260709-5820` | Production-like verification |
+| `main` | `firebase-production` | `yokai-config-260709-5820` | User data and releases |
+
+Feature pull requests target `develop`. Promotion pull requests move the same
+commit from `develop` to `staging`, then from `staging` to `main`. Every pull
+request runs the Firestore emulator tests. A merge to a long-lived branch deploys
+only to its matching Firebase project; production deployment and releases also
+wait for approval from `spencerbull`.
+
+## Set up the Google backends
 
 Prerequisites:
 
 1. Install and authenticate the Google Cloud and Firebase CLIs.
-2. Use a Google Cloud project without a billing account to stay on Firebase's
-   Spark plan.
-3. Run the setup script from the repository root:
+2. Keep all three projects disconnected from billing to stay on Firebase's Spark
+   plan.
+3. Run the setup script for each environment from the repository root:
 
 ```bash
-export GCP_PROJECT_ID="your-project-id"
-./deploy/gcp/setup-firebase.sh
+CREATE_PROJECT=1 DEPLOY_STAGE=development \
+  GCP_PROJECT_ID=yokai-config-dev-260709-5820 \
+  ./deploy/gcp/setup-firebase.sh
+
+CREATE_PROJECT=1 DEPLOY_STAGE=staging \
+  GCP_PROJECT_ID=yokai-config-stg-260709-5820 \
+  ./deploy/gcp/setup-firebase.sh
+
+DEPLOY_STAGE=production \
+  GCP_PROJECT_ID=yokai-config-260709-5820 \
+  ./deploy/gcp/setup-firebase.sh
 ```
 
-The script adds Firebase, creates the single free Firestore database in
-`us-central1`, creates a Firebase Web App if necessary, and deploys
-`firestore.rules`. It prints the Firebase project configuration containing the
-public API key.
+The script creates a project when explicitly allowed, verifies billing is off,
+adds Firebase, creates the free Firestore database in
+`us-central1` with delete protection, creates a Firebase Web App, and deploys
+`firestore.rules`. It prints the public app ID and API key.
 
 ### Continuous deployment
 
-Configure keyless GitHub Actions access once:
+Configure keyless GitHub Actions access for each project:
 
 ```bash
-export GCP_PROJECT_ID="your-project-id"
-./deploy/gcp/setup-github-actions.sh
+DEPLOY_STAGE=development GCP_PROJECT_ID=yokai-config-dev-260709-5820 \
+  ./deploy/gcp/setup-github-actions.sh
+DEPLOY_STAGE=staging GCP_PROJECT_ID=yokai-config-stg-260709-5820 \
+  ./deploy/gcp/setup-github-actions.sh
+DEPLOY_STAGE=production GCP_PROJECT_ID=yokai-config-260709-5820 \
+  ./deploy/gcp/setup-github-actions.sh
+
+./deploy/github/setup-branch-governance.sh
 ```
 
-The setup creates a dedicated service account with a narrow custom rules-deployer
-role and a workload identity provider restricted to this repository's immutable
-GitHub ID, the `main` branch, the `firebase-production` environment, and this
-specific deployment workflow. It also creates the required GitHub repository
-variables. It creates no service-account key or GitHub secret. Pull requests run
-the rules against the Firestore emulator; changes merged to `main` rerun those
-tests and deploy the rules only after they pass.
+Each environment receives a dedicated service account with a narrow custom
+rules-deployer role and its own workload identity provider. Trust is restricted
+to this repository's immutable GitHub ID, the environment's exact branch, the
+matching GitHub environment, and this deployment workflow. Public client values
+and deployment coordinates are environment-scoped GitHub variables. No
+service-account key or GitHub secret is created.
 
-Next, in **Google Auth Platform** for the same project:
+The branch-governance script blocks direct pushes, force pushes, and deletion of
+`develop`, `staging`, and `main`; requires the complete CI suite and resolved
+review threads; and requires code-owner approval from `spencerbull`. Spencer can
+bypass approval only while merging a pull request, which permits a sole
+maintainer to merge their own reviewed work without allowing direct pushes.
+
+Next, in **Google Auth Platform** for each project:
 
 1. Configure the branding/audience and add test users while the app is in testing.
 2. Enable Google as a Firebase Authentication sign-in provider.
@@ -98,8 +136,8 @@ Next, in **Google Auth Platform** for the same project:
 4. Configure release builds with the OAuth client values:
 
 ```bash
-gh variable set YOKAI_GOOGLE_CLIENT_ID --body "000000000000-example.apps.googleusercontent.com"
-gh variable set YOKAI_GOOGLE_CLIENT_SECRET --body "desktop-client-secret"
+gh variable set YOKAI_GOOGLE_CLIENT_ID --env firebase-production --body "000000000000-example.apps.googleusercontent.com"
+gh variable set YOKAI_GOOGLE_CLIENT_SECRET --env firebase-production --body "desktop-client-secret"
 ```
 
 Desktop OAuth client secrets identify an installed app but cannot be kept

--- a/docs/cloud-device-config.md
+++ b/docs/cloud-device-config.md
@@ -4,6 +4,61 @@ Yokai can save and restore the `devices` section of `~/.config/yokai/config.json
 with Firebase Authentication and Cloud Firestore. Other local settings, deploy
 history, and the Hugging Face token are not synchronized.
 
+## Quick start
+
+Official releases include the production Firebase and Google OAuth settings.
+Start by signing in and checking whether this account already has a backup:
+
+```bash
+yokai cloud login
+yokai cloud status
+```
+
+Create the encrypted backup:
+
+```bash
+yokai cloud save
+```
+
+On the first save, Yokai asks you to create and confirm a passphrase with at
+least 12 characters. Save it in a password manager: Yokai cannot recover a lost
+passphrase, and Firebase stores only ciphertext. Later saves require the current
+passphrase before replacing the existing backup. Yokai refuses to upload an
+empty device list unless `--allow-empty` is explicitly supplied.
+
+To inspect and restore a backup:
+
+```bash
+# Shows whether a backup exists and when it was last updated
+yokai cloud status
+
+# Also decrypts the backup and reports its device count
+yokai cloud status --verify
+
+# Previews the local/cloud device counts before changing anything
+yokai cloud load
+```
+
+Restore replaces only the device list. Yokai preserves all other settings,
+writes a private timestamped copy of the local config, and reports that backup
+path in the result. If the daemon is not available to reload the restored list,
+restart Yokai. To undo, copy the reported backup over the active path shown by
+`yokai config path`, then restart Yokai.
+
+`cloud logout` removes the Google/Firebase credentials from this computer but
+does not delete the encrypted cloud backup. Permanent deletion is a separate,
+explicit action:
+
+```bash
+yokai cloud delete --yes
+yokai cloud logout
+```
+
+For non-interactive automation, set `YOKAI_CLOUD_PASSPHRASE` and use `--yes`
+when replacing an existing cloud or local device list. Process environment
+values may be visible to other processes owned by the same operating-system
+user.
+
 ## Architecture
 
 ```text
@@ -170,14 +225,7 @@ displays a newly created secret in full for a limited time. Store it directly in
 the matching GitHub Environment; if it is lost, create a replacement, verify
 login, and disable the superseded secret.
 
-## Sign in and use
-
-Official releases include the public Firebase project configuration and the
-desktop OAuth client configured by the release workflow, so sign-in is normally:
-
-```bash
-yokai cloud login
-```
+## Self-hosted and local builds
 
 For a self-hosted backend or a locally built binary, supply the configuration
 explicitly:
@@ -188,30 +236,7 @@ yokai cloud login \
   --api-key "firebase-public-api-key" \
   --client-id "000000000000-example.apps.googleusercontent.com" \
   --client-secret "desktop-client-secret"
-
-# Encrypt and upload only device records
-yokai cloud save
-
-# Restore device records; existing config is backed up first
-yokai cloud load
-
-# Check or remove local login state
-yokai cloud status
-yokai cloud logout
-
-# Permanently delete the server-side ciphertext
-yokai cloud delete --yes
 ```
-
-Interactive commands read the encryption passphrase without echo. `cloud save`
-asks for it twice before replacing the existing cloud snapshot, reducing the
-chance that a typo makes the last usable snapshot inaccessible. Use a long,
-unique passphrase and keep it in a password manager. Automation can set
-`YOKAI_CLOUD_PASSPHRASE` to bypass the prompt, but a process environment may be
-visible to other processes owned by the same operating-system user.
-
-`yokai cloud load` replaces only devices and writes a timestamped local backup.
-If the local daemon is running, the CLI asks it to reload the new device list.
 
 ## Security operations
 

--- a/docs/cloud-device-config.md
+++ b/docs/cloud-device-config.md
@@ -76,7 +76,8 @@ wait for approval from `spencerbull`.
 
 Prerequisites:
 
-1. Install and authenticate the Google Cloud and Firebase CLIs.
+1. Install and authenticate the Google Cloud and Firebase CLIs, GitHub CLI
+   (`gh`), and `jq`.
 2. Keep all three projects disconnected from billing to stay on Firebase's Spark
    plan.
 3. Run the setup script for each environment from the repository root:
@@ -122,27 +123,52 @@ matching GitHub environment, and this deployment workflow. Public client values
 and deployment coordinates are environment-scoped GitHub variables. No
 service-account key or GitHub secret is created.
 
-The branch-governance script blocks direct pushes, force pushes, and deletion of
-`develop`, `staging`, and `main`; requires the complete CI suite and resolved
-review threads; and requires code-owner approval from `spencerbull`. Spencer can
-bypass approval only while merging a pull request, which permits a sole
-maintainer to merge their own reviewed work without allowing direct pushes.
+The branch-governance script uses separate rulesets for non-bypassable branch,
+CI, and resolved-thread gates and for code-owner approval. It blocks direct
+pushes, force pushes, and deletion of `develop`, `staging`, and `main`; requires
+the complete CI suite and resolved review threads; and requires code-owner
+approval from `spencerbull`. Spencer can bypass only the approval ruleset while
+merging a pull request, which permits a sole maintainer to merge their own
+reviewed work without bypassing CI, unresolved threads, or direct-push controls.
 
 Next, in **Google Auth Platform** for each project:
 
-1. Configure the branding/audience and add test users while the app is in testing.
+1. Configure the branding/audience. Keep every environment in **Testing** with
+   an explicit test-user allowlist until its release gate. Never publish the
+   development or staging apps; publish only the production app when it is ready
+   for real users. Firebase CLI provisioning can leave a newly created audience
+   in production, so verify this setting after enabling Google sign-in.
 2. Enable Google as a Firebase Authentication sign-in provider.
 3. Create an OAuth client with application type **Desktop app**.
-4. Configure release builds with the OAuth client values:
+4. Store each desktop client in its matching GitHub Environment:
 
 ```bash
-gh variable set YOKAI_GOOGLE_CLIENT_ID --env firebase-production --body "000000000000-example.apps.googleusercontent.com"
-gh variable set YOKAI_GOOGLE_CLIENT_SECRET --env firebase-production --body "desktop-client-secret"
+gh variable set YOKAI_GOOGLE_CLIENT_ID --repo spencerbull/Yokai \
+  --env firebase-development --body "development-client-id.apps.googleusercontent.com"
+gh variable set YOKAI_GOOGLE_CLIENT_SECRET --repo spencerbull/Yokai \
+  --env firebase-development --body "development-client-secret"
+
+gh variable set YOKAI_GOOGLE_CLIENT_ID --repo spencerbull/Yokai \
+  --env firebase-staging --body "staging-client-id.apps.googleusercontent.com"
+gh variable set YOKAI_GOOGLE_CLIENT_SECRET --repo spencerbull/Yokai \
+  --env firebase-staging --body "staging-client-secret"
+
+gh variable set YOKAI_GOOGLE_CLIENT_ID --repo spencerbull/Yokai \
+  --env firebase-production --body "production-client-id.apps.googleusercontent.com"
+gh variable set YOKAI_GOOGLE_CLIENT_SECRET --repo spencerbull/Yokai \
+  --env firebase-production --body "production-client-secret"
 ```
 
+Replace each placeholder with the distinct client ID and secret created for
+that environment; never copy one environment's values into another.
+
 Desktop OAuth client secrets identify an installed app but cannot be kept
-confidential. Yokai uses the secret only for the authorization-code exchange and
-does not save it after login.
+confidential. Official release binaries contain the linker-injected production
+desktop client secret. Yokai uses it only for the authorization-code exchange
+and does not copy a runtime-supplied secret into `cloud-auth.json`. Google only
+displays a newly created secret in full for a limited time. Store it directly in
+the matching GitHub Environment; if it is lost, create a replacement, verify
+login, and disable the superseded secret.
 
 ## Sign in and use
 
@@ -190,8 +216,9 @@ If the local daemon is running, the CLI asks it to reload the new device list.
 ## Security operations
 
 - Deploy the checked-in Firestore rules before enabling sign-in.
-- Keep the Firebase-provisioned API key restricted to Firebase APIs. It is a
-  public project identifier, not authorization; Security Rules authorize data.
+- Keep the Firebase-provisioned API key restricted to Identity Toolkit and
+  Secure Token. It is a public project identifier, not authorization; Security
+  Rules authorize data. The setup script applies this restriction.
 - Do not grant application users IAM roles in the Google Cloud project.
 - Do not enable phone authentication, Cloud Functions, or other paid products.
 - Review Firebase Authentication users and Firestore usage periodically.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,11 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "singleProjectMode": true
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,33 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /device_configs/{userId} {
+      function isOwner() {
+        return request.auth != null && request.auth.uid == userId;
+      }
+
+      function isEncryptedEnvelope() {
+        return request.resource.data.keys().hasOnly([
+          'version', 'cipher', 'kdf', 'salt', 'nonce', 'ciphertext'
+        ])
+        && request.resource.data.version == 1
+        && request.resource.data.cipher == 'aes-256-gcm'
+        && request.resource.data.kdf == 'argon2id-3-65536-4'
+        && request.resource.data.salt is string
+        && request.resource.data.salt.size() <= 32
+        && request.resource.data.nonce is string
+        && request.resource.data.nonce.size() <= 24
+        && request.resource.data.ciphertext is string
+        && request.resource.data.ciphertext.size() <= 900000;
+      }
+
+      allow read, delete: if isOwner();
+      allow create, update: if isOwner() && isEncryptedEnvelope();
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	golang.org/x/crypto v0.48.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.40.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -750,6 +750,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -89,7 +89,7 @@ func runCloudSave(ctx context.Context) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 	envelope, err := cloudsync.Encrypt(cloudsync.Snapshot{
-		Version: config.ConfigVersion,
+		Version: cloudsync.SnapshotVersion,
 		Devices: append([]config.Device(nil), cfg.Devices...),
 	}, passphrase)
 	if err != nil {
@@ -137,7 +137,7 @@ func runCloudLoad(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	cfg.Devices = append([]config.Device(nil), snapshot.Devices...)
+	applyCloudSnapshot(cfg, snapshot)
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("saving loaded config: %w", err)
 	}
@@ -151,6 +151,10 @@ func runCloudLoad(ctx context.Context) error {
 		"daemon_reloaded":  reloaded,
 	})
 	return nil
+}
+
+func applyCloudSnapshot(cfg *config.Config, snapshot cloudsync.Snapshot) {
+	cfg.Devices = append([]config.Device(nil), snapshot.Devices...)
 }
 
 func runCloudStatus(ctx context.Context) error {

--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/spencerbull/yokai/internal/cloudsync"
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+// RunCloud dispatches encrypted cloud device configuration commands.
+func RunCloud(args []string) {
+	if len(args) == 0 {
+		exitError("usage: yokai cloud <login|save|load|status|delete|logout>")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	var err error
+	switch args[0] {
+	case "login":
+		err = runCloudLogin(ctx, args[1:])
+	case "save":
+		err = runCloudSave(ctx)
+	case "load":
+		err = runCloudLoad(ctx)
+	case "status":
+		err = runCloudStatus(ctx)
+	case "delete":
+		err = runCloudDelete(ctx, args[1:])
+	case "logout":
+		err = runCloudLogout()
+	default:
+		err = fmt.Errorf("unknown cloud command %q", args[0])
+	}
+	if err != nil {
+		exitError(err.Error())
+	}
+}
+
+func runCloudLogin(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("cloud login", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	projectID := flags.String("project-id", os.Getenv("YOKAI_FIREBASE_PROJECT_ID"), "Firebase project ID")
+	apiKey := flags.String("api-key", os.Getenv("YOKAI_FIREBASE_API_KEY"), "Firebase web API key")
+	clientID := flags.String("client-id", os.Getenv("YOKAI_GOOGLE_CLIENT_ID"), "Google desktop OAuth client ID")
+	clientSecret := flags.String("client-secret", os.Getenv("YOKAI_GOOGLE_CLIENT_SECRET"), "Google desktop OAuth client secret")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	credentials, err := cloudsync.Login(ctx, cloudsync.LoginOptions{
+		ProjectID:          strings.TrimSpace(*projectID),
+		APIKey:             strings.TrimSpace(*apiKey),
+		GoogleClientID:     strings.TrimSpace(*clientID),
+		GoogleClientSecret: strings.TrimSpace(*clientSecret),
+		AnnounceURL: func(url string) {
+			fmt.Fprintln(os.Stderr, "Opening Google sign-in in your browser.")
+			fmt.Fprintf(os.Stderr, "If it does not open, visit:\n%s\n", url)
+		},
+	})
+	if err != nil {
+		return err
+	}
+	outputJSON(map[string]interface{}{
+		"status":     "logged_in",
+		"email":      credentials.Email,
+		"project_id": credentials.ProjectID,
+	})
+	return nil
+}
+
+func runCloudSave(ctx context.Context) error {
+	passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	envelope, err := cloudsync.Encrypt(cloudsync.Snapshot{
+		Version: config.ConfigVersion,
+		Devices: append([]config.Device(nil), cfg.Devices...),
+	}, passphrase)
+	if err != nil {
+		return err
+	}
+	client, credentials, err := cloudsync.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	metadata, err := client.Put(ctx, envelope)
+	if err != nil {
+		return err
+	}
+	outputJSON(map[string]interface{}{
+		"status":       "saved",
+		"email":        credentials.Email,
+		"device_count": len(cfg.Devices),
+		"updated_at":   metadata.UpdatedAt,
+	})
+	return nil
+}
+
+func runCloudLoad(ctx context.Context) error {
+	client, credentials, err := cloudsync.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	envelope, metadata, err := client.Get(ctx)
+	if err != nil {
+		return err
+	}
+	passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
+	if err != nil {
+		return err
+	}
+	snapshot, err := cloudsync.Decrypt(envelope, passphrase)
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading local config: %w", err)
+	}
+	backupPath, err := backupLocalConfig()
+	if err != nil {
+		return err
+	}
+	cfg.Devices = append([]config.Device(nil), snapshot.Devices...)
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("saving loaded config: %w", err)
+	}
+	reloaded := reloadDaemonAfterCloudLoad(cfg)
+	outputJSON(map[string]interface{}{
+		"status":           "loaded",
+		"email":            credentials.Email,
+		"device_count":     len(snapshot.Devices),
+		"cloud_updated_at": metadata.UpdatedAt,
+		"backup_path":      backupPath,
+		"daemon_reloaded":  reloaded,
+	})
+	return nil
+}
+
+func runCloudStatus(ctx context.Context) error {
+	_, credentials, err := cloudsync.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	outputJSON(map[string]interface{}{
+		"status":       "logged_in",
+		"email":        credentials.Email,
+		"project_id":   credentials.ProjectID,
+		"token_expiry": credentials.Token.Expiry,
+	})
+	return nil
+}
+
+func runCloudDelete(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("cloud delete", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	confirmed := flags.Bool("yes", false, "permanently delete without prompting")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if !*confirmed {
+		return fmt.Errorf("cloud delete is permanent; rerun with --yes")
+	}
+	client, credentials, err := cloudsync.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	if err := client.Delete(ctx); err != nil {
+		return err
+	}
+	outputJSON(map[string]interface{}{"status": "deleted", "email": credentials.Email})
+	return nil
+}
+
+func runCloudLogout() error {
+	if err := cloudsync.RemoveCredentials(); err != nil {
+		return err
+	}
+	outputJSON(map[string]string{"status": "logged_out"})
+	return nil
+}
+
+func readCloudPassphrase(prompt string) (string, error) {
+	if value := os.Getenv("YOKAI_CLOUD_PASSPHRASE"); value != "" {
+		return value, nil
+	}
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return "", fmt.Errorf("set YOKAI_CLOUD_PASSPHRASE when stdin is not a terminal")
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	value, err := term.ReadPassword(fd)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("reading passphrase: %w", err)
+	}
+	return string(value), nil
+}
+
+func backupLocalConfig() (string, error) {
+	path, err := config.ConfigPath()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("reading local config for backup: %w", err)
+	}
+	backup := filepath.Join(filepath.Dir(path), fmt.Sprintf("config.cloud-backup-%s.json", time.Now().UTC().Format("20060102T150405.000000000Z")))
+	file, err := os.OpenFile(backup, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return "", fmt.Errorf("writing local config backup: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(backup)
+		return "", fmt.Errorf("writing local config backup: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("closing local config backup: %w", err)
+	}
+	return backup, nil
+}
+
+func reloadDaemonAfterCloudLoad(cfg *config.Config) bool {
+	addr := cfg.Daemon.Listen
+	if addr == "" {
+		addr = "127.0.0.1:7473"
+	}
+	resp, err := http.Post("http://"+addr+"/reload", "application/json", nil)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}

--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -50,10 +50,10 @@ func RunCloud(args []string) {
 func runCloudLogin(ctx context.Context, args []string) error {
 	flags := flag.NewFlagSet("cloud login", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
-	projectID := flags.String("project-id", os.Getenv("YOKAI_FIREBASE_PROJECT_ID"), "Firebase project ID")
-	apiKey := flags.String("api-key", os.Getenv("YOKAI_FIREBASE_API_KEY"), "Firebase web API key")
-	clientID := flags.String("client-id", os.Getenv("YOKAI_GOOGLE_CLIENT_ID"), "Google desktop OAuth client ID")
-	clientSecret := flags.String("client-secret", os.Getenv("YOKAI_GOOGLE_CLIENT_SECRET"), "Google desktop OAuth client secret")
+	projectID := flags.String("project-id", envOrDefault("YOKAI_FIREBASE_PROJECT_ID", cloudsync.DefaultProjectID), "Firebase project ID")
+	apiKey := flags.String("api-key", envOrDefault("YOKAI_FIREBASE_API_KEY", cloudsync.DefaultAPIKey), "Firebase web API key")
+	clientID := flags.String("client-id", envOrDefault("YOKAI_GOOGLE_CLIENT_ID", cloudsync.DefaultGoogleClientID), "Google desktop OAuth client ID")
+	clientSecret := flags.String("client-secret", envOrDefault("YOKAI_GOOGLE_CLIENT_SECRET", cloudsync.DefaultGoogleClientSecret), "Google desktop OAuth client secret")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func runCloudLogin(ctx context.Context, args []string) error {
 }
 
 func runCloudSave(ctx context.Context) error {
-	passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
+	passphrase, err := readCloudSavePassphrase()
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func runCloudLoad(ctx context.Context) error {
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("saving loaded config: %w", err)
 	}
-	reloaded := reloadDaemonAfterCloudLoad(cfg)
+	reloaded := reloadDaemonAfterCloudLoad(ctx, cfg)
 	outputJSON(map[string]interface{}{
 		"status":           "loaded",
 		"email":            credentials.Email,
@@ -213,6 +213,31 @@ func readCloudPassphrase(prompt string) (string, error) {
 	return string(value), nil
 }
 
+func readCloudSavePassphrase() (string, error) {
+	if value := os.Getenv("YOKAI_CLOUD_PASSPHRASE"); value != "" {
+		return value, nil
+	}
+	passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
+	if err != nil {
+		return "", err
+	}
+	confirmation, err := readCloudPassphrase("Confirm cloud encryption passphrase: ")
+	if err != nil {
+		return "", err
+	}
+	if err := validatePassphraseConfirmation(passphrase, confirmation); err != nil {
+		return "", err
+	}
+	return passphrase, nil
+}
+
+func validatePassphraseConfirmation(passphrase, confirmation string) error {
+	if passphrase != confirmation {
+		return fmt.Errorf("cloud encryption passphrases do not match")
+	}
+	return nil
+}
+
 func backupLocalConfig() (string, error) {
 	path, err := config.ConfigPath()
 	if err != nil {
@@ -241,15 +266,30 @@ func backupLocalConfig() (string, error) {
 	return backup, nil
 }
 
-func reloadDaemonAfterCloudLoad(cfg *config.Config) bool {
+func reloadDaemonAfterCloudLoad(ctx context.Context, cfg *config.Config) bool {
+	return reloadDaemonWithClient(ctx, cfg, &http.Client{Timeout: 3 * time.Second})
+}
+
+func reloadDaemonWithClient(ctx context.Context, cfg *config.Config, client *http.Client) bool {
 	addr := cfg.Daemon.Listen
 	if addr == "" {
 		addr = "127.0.0.1:7473"
 	}
-	resp, err := http.Post("http://"+addr+"/reload", "application/json", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+addr+"/reload", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return false
 	}
 	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -18,38 +21,94 @@ import (
 
 // RunCloud dispatches encrypted cloud device configuration commands.
 func RunCloud(args []string) {
-	if len(args) == 0 {
-		exitError("usage: yokai cloud <login|save|load|status|delete|logout>")
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-
-	var err error
-	switch args[0] {
-	case "login":
-		err = runCloudLogin(ctx, args[1:])
-	case "save":
-		err = runCloudSave(ctx)
-	case "load":
-		err = runCloudLoad(ctx)
-	case "status":
-		err = runCloudStatus(ctx)
-	case "delete":
-		err = runCloudDelete(ctx, args[1:])
-	case "logout":
-		err = runCloudLogout()
-	default:
-		err = fmt.Errorf("unknown cloud command %q", args[0])
-	}
-	if err != nil {
+	if err := runCloud(ctx, args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
 		exitError(err.Error())
 	}
+}
+
+func runCloud(ctx context.Context, args []string) error {
+	if len(args) == 0 || args[0] == "help" || args[0] == "--help" || args[0] == "-h" {
+		printCloudUsage(os.Stdout)
+		return nil
+	}
+	switch args[0] {
+	case "login":
+		return runCloudLogin(ctx, args[1:])
+	case "save":
+		return runCloudSave(ctx, args[1:])
+	case "load":
+		return runCloudLoad(ctx, args[1:])
+	case "status":
+		return runCloudStatus(ctx, args[1:])
+	case "delete":
+		return runCloudDelete(ctx, args[1:])
+	case "logout":
+		return runCloudLogout(args[1:])
+	default:
+		return fmt.Errorf("unknown cloud command %q; run 'yokai cloud --help'", args[0])
+	}
+}
+
+func printCloudUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, `Securely back up Yokai device records.
+
+Usage:
+  yokai cloud login [flags]       Sign in with Google on this computer
+  yokai cloud save [flags]        Encrypt and upload local devices
+  yokai cloud load [flags]        Preview and replace local devices
+  yokai cloud status [--verify]   Show login and backup status
+  yokai cloud delete --yes        Permanently delete the cloud backup
+  yokai cloud logout              Sign out on this computer
+
+Run 'yokai cloud <command> --help' for command-specific options.
+Only device records are synced. Other Yokai settings stay local.
+`)
+}
+
+type cloudConfigClient interface {
+	Put(context.Context, cloudsync.Envelope) (cloudsync.Metadata, error)
+	Get(context.Context) (cloudsync.Envelope, cloudsync.Metadata, error)
+	Delete(context.Context) error
+}
+
+type cloudCommandInteraction struct {
+	stdin              io.Reader
+	stderr             io.Writer
+	isTerminal         bool
+	readPassphrase     func(string) (string, error)
+	readSavePassphrase func() (string, error)
+	output             func(interface{})
+}
+
+func defaultCloudCommandInteraction() cloudCommandInteraction {
+	return cloudCommandInteraction{
+		stdin:              os.Stdin,
+		stderr:             os.Stderr,
+		isTerminal:         term.IsTerminal(int(os.Stdin.Fd())),
+		readPassphrase:     readCloudPassphrase,
+		readSavePassphrase: readCloudSavePassphrase,
+		output:             outputJSON,
+	}
+}
+
+type cloudLoadEffects struct {
+	backup func() (string, error)
+	save   func(*config.Config) error
+	reload func(context.Context, *config.Config) bool
 }
 
 func runCloudLogin(ctx context.Context, args []string) error {
 	flags := flag.NewFlagSet("cloud login", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
+	flags.Usage = func() {
+		_, _ = fmt.Fprintln(flags.Output(), "Usage: yokai cloud login [--project-id ID --api-key KEY --client-id ID --client-secret SECRET]")
+		flags.PrintDefaults()
+	}
 	projectID := flags.String("project-id", envOrDefault("YOKAI_FIREBASE_PROJECT_ID", cloudsync.DefaultProjectID), "Firebase project ID")
 	apiKey := flags.String("api-key", envOrDefault("YOKAI_FIREBASE_API_KEY", cloudsync.DefaultAPIKey), "Firebase web API key")
 	clientID := flags.String("client-id", envOrDefault("YOKAI_GOOGLE_CLIENT_ID", cloudsync.DefaultGoogleClientID), "Google desktop OAuth client ID")
@@ -57,15 +116,18 @@ func runCloudLogin(ctx context.Context, args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("cloud login does not accept positional arguments")
+	}
 
+	fmt.Fprintln(os.Stderr, "Opening Google sign-in in your browser...")
 	credentials, err := cloudsync.Login(ctx, cloudsync.LoginOptions{
 		ProjectID:          strings.TrimSpace(*projectID),
 		APIKey:             strings.TrimSpace(*apiKey),
 		GoogleClientID:     strings.TrimSpace(*clientID),
 		GoogleClientSecret: strings.TrimSpace(*clientSecret),
 		AnnounceURL: func(url string) {
-			fmt.Fprintln(os.Stderr, "Opening Google sign-in in your browser.")
-			fmt.Fprintf(os.Stderr, "If it does not open, visit:\n%s\n", url)
+			fmt.Fprintf(os.Stderr, "If the browser does not open, continue sign-in at:\n%s\n", url)
 		},
 	})
 	if err != nil {
@@ -75,18 +137,86 @@ func runCloudLogin(ctx context.Context, args []string) error {
 		"status":     "logged_in",
 		"email":      credentials.Email,
 		"project_id": credentials.ProjectID,
+		"message":    "Signed in on this computer. Run 'yokai cloud status' to check for an existing backup.",
 	})
 	return nil
 }
 
-func runCloudSave(ctx context.Context) error {
-	passphrase, err := readCloudSavePassphrase()
-	if err != nil {
+func runCloudSave(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("cloud save", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	confirmed := flags.Bool("yes", false, "replace an existing cloud backup without prompting")
+	allowEmpty := flags.Bool("allow-empty", false, "allow an empty device list to replace the cloud backup")
+	flags.Usage = func() {
+		_, _ = fmt.Fprintln(flags.Output(), "Usage: yokai cloud save [--yes] [--allow-empty]")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("cloud save does not accept positional arguments")
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
+	}
+	if err := validateCloudSaveConfig(cfg, *allowEmpty); err != nil {
+		return err
+	}
+	client, credentials, err := cloudsync.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	return saveCloudConfig(ctx, client, credentials, cfg, *confirmed, defaultCloudCommandInteraction())
+}
+
+func validateCloudSaveConfig(cfg *config.Config, allowEmpty bool) error {
+	if len(cfg.Devices) == 0 && !allowEmpty {
+		return fmt.Errorf("local config has no devices; refusing to replace the cloud backup (use --allow-empty only if this is intentional)")
+	}
+	return nil
+}
+
+func saveCloudConfig(ctx context.Context, client cloudConfigClient, credentials *cloudsync.Credentials, cfg *config.Config, confirmed bool, interaction cloudCommandInteraction) error {
+	existing, existingMetadata, err := client.Get(ctx)
+	hasExisting := err == nil
+	if err != nil && !errors.Is(err, cloudsync.ErrNoCloudConfig) {
+		return err
+	}
+	if hasExisting && !confirmed {
+		if !interaction.isTerminal {
+			return fmt.Errorf("a cloud backup already exists; rerun with --yes to replace it")
+		}
+		_, _ = fmt.Fprintf(interaction.stderr, "Replace the backup for %s from %s with %d local device(s)?\n", credentials.Email, existingMetadata.UpdatedAt.Local().Format(time.RFC1123), len(cfg.Devices))
+		ok, err := readCloudConfirmation(interaction.stdin, interaction.stderr, "Continue? [y/N]: ")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			interaction.output(map[string]string{"status": "cancelled", "message": "Cloud backup was not changed."})
+			return nil
+		}
+	}
+	if !hasExisting {
+		_, _ = fmt.Fprintf(interaction.stderr, "Creating an encrypted backup for %s with %d device(s).\n", credentials.Email, len(cfg.Devices))
+	}
+
+	var passphrase string
+	if hasExisting {
+		passphrase, err = interaction.readPassphrase("Existing cloud backup passphrase: ")
+		if err != nil {
+			return err
+		}
+		if _, err := cloudsync.Decrypt(existing, passphrase); err != nil {
+			return fmt.Errorf("cannot replace the existing backup: %w", err)
+		}
+	} else {
+		passphrase, err = interaction.readSavePassphrase()
+		if err != nil {
+			return err
+		}
 	}
 	envelope, err := cloudsync.Encrypt(cloudsync.Snapshot{
 		Version: cloudsync.SnapshotVersion,
@@ -95,37 +225,36 @@ func runCloudSave(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	client, credentials, err := cloudsync.NewClient(ctx)
-	if err != nil {
-		return err
-	}
 	metadata, err := client.Put(ctx, envelope)
 	if err != nil {
 		return err
 	}
-	outputJSON(map[string]interface{}{
+	interaction.output(map[string]interface{}{
 		"status":       "saved",
 		"email":        credentials.Email,
 		"device_count": len(cfg.Devices),
 		"updated_at":   metadata.UpdatedAt,
+		"message":      fmt.Sprintf("Encrypted backup saved with %d device(s).", len(cfg.Devices)),
 	})
 	return nil
 }
 
-func runCloudLoad(ctx context.Context) error {
+func runCloudLoad(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("cloud load", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	confirmed := flags.Bool("yes", false, "replace local devices without prompting")
+	flags.Usage = func() {
+		_, _ = fmt.Fprintln(flags.Output(), "Usage: yokai cloud load [--yes]")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("cloud load does not accept positional arguments")
+	}
+
 	client, credentials, err := cloudsync.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-	envelope, metadata, err := client.Get(ctx)
-	if err != nil {
-		return err
-	}
-	passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
-	if err != nil {
-		return err
-	}
-	snapshot, err := cloudsync.Decrypt(envelope, passphrase)
 	if err != nil {
 		return err
 	}
@@ -133,23 +262,72 @@ func runCloudLoad(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("loading local config: %w", err)
 	}
-	backupPath, err := backupLocalConfig()
+	return loadCloudConfig(ctx, client, credentials, cfg, *confirmed, defaultCloudCommandInteraction(), cloudLoadEffects{
+		backup: backupLocalConfig,
+		save:   config.Save,
+		reload: reloadDaemonAfterCloudLoad,
+	})
+}
+
+func loadCloudConfig(ctx context.Context, client cloudConfigClient, credentials *cloudsync.Credentials, cfg *config.Config, confirmed bool, interaction cloudCommandInteraction, effects cloudLoadEffects) error {
+	envelope, metadata, err := client.Get(ctx)
+	if err != nil {
+		return err
+	}
+	if !confirmed && !interaction.isTerminal {
+		return fmt.Errorf("cloud load replaces the local device list; rerun with --yes after reviewing the backup")
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintf(interaction.stderr, "Backup found for %s from %s. Enter its passphrase to preview the restore.\n", credentials.Email, metadata.UpdatedAt.Local().Format(time.RFC1123))
+	}
+	passphrase, err := interaction.readPassphrase("Cloud encryption passphrase: ")
+	if err != nil {
+		return err
+	}
+	snapshot, err := cloudsync.Decrypt(envelope, passphrase)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		_, _ = fmt.Fprintf(interaction.stderr, "Restore %d device(s) saved %s for %s?\n", len(snapshot.Devices), metadata.UpdatedAt.Local().Format(time.RFC1123), credentials.Email)
+		_, _ = fmt.Fprintf(interaction.stderr, "This replaces %d local device(s). Other Yokai settings are preserved.\n", len(cfg.Devices))
+		ok, err := readCloudConfirmation(interaction.stdin, interaction.stderr, "Continue? [y/N]: ")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			interaction.output(map[string]string{"status": "cancelled", "message": "Local devices were not changed."})
+			return nil
+		}
+	}
+	backupPath, err := effects.backup()
 	if err != nil {
 		return err
 	}
 	applyCloudSnapshot(cfg, snapshot)
-	if err := config.Save(cfg); err != nil {
+	if err := effects.save(cfg); err != nil {
 		return fmt.Errorf("saving loaded config: %w", err)
 	}
-	reloaded := reloadDaemonAfterCloudLoad(ctx, cfg)
-	outputJSON(map[string]interface{}{
+	reloaded := effects.reload(ctx, cfg)
+	result := map[string]interface{}{
 		"status":           "loaded",
 		"email":            credentials.Email,
 		"device_count":     len(snapshot.Devices),
 		"cloud_updated_at": metadata.UpdatedAt,
 		"backup_path":      backupPath,
 		"daemon_reloaded":  reloaded,
-	})
+		"message":          fmt.Sprintf("Restored %d device(s); other Yokai settings were preserved.", len(snapshot.Devices)),
+	}
+	if backupPath != "" {
+		result["undo_backup_path"] = backupPath
+	}
+	if reloaded {
+		result["daemon_reload_status"] = "reloaded"
+	} else {
+		result["daemon_reload_status"] = "not_running_or_unreachable"
+		result["next_step"] = "Restart Yokai to use the restored device list."
+	}
+	interaction.output(result)
 	return nil
 }
 
@@ -157,17 +335,81 @@ func applyCloudSnapshot(cfg *config.Config, snapshot cloudsync.Snapshot) {
 	cfg.Devices = append([]config.Device(nil), snapshot.Devices...)
 }
 
-func runCloudStatus(ctx context.Context) error {
-	_, credentials, err := cloudsync.NewClient(ctx)
+func runCloudStatus(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("cloud status", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	verify := flags.Bool("verify", false, "decrypt the backup and report its device count")
+	flags.Usage = func() {
+		_, _ = fmt.Fprintln(flags.Output(), "Usage: yokai cloud status [--verify]")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("cloud status does not accept positional arguments")
+	}
+
+	_, err := cloudsync.LoadCredentials()
+	if errors.Is(err, cloudsync.ErrNotLoggedIn) {
+		outputJSON(map[string]interface{}{
+			"status":        "logged_out",
+			"backup_status": "unknown_until_login",
+			"message":       "This computer is not signed in. Run 'yokai cloud login' to check or create a backup.",
+		})
+		return nil
+	}
 	if err != nil {
 		return err
 	}
-	outputJSON(map[string]interface{}{
-		"status":       "logged_in",
-		"email":        credentials.Email,
-		"project_id":   credentials.ProjectID,
-		"token_expiry": credentials.Token.Expiry,
-	})
+	client, credentials, err := cloudsync.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading local config: %w", err)
+	}
+	envelope, metadata, err := client.Get(ctx)
+	if errors.Is(err, cloudsync.ErrNoCloudConfig) {
+		outputJSON(map[string]interface{}{
+			"status":             "logged_in",
+			"email":              credentials.Email,
+			"project_id":         credentials.ProjectID,
+			"backup_exists":      false,
+			"local_device_count": len(cfg.Devices),
+			"token_expiry":       credentials.Token.Expiry,
+			"message":            "Signed in, but no cloud backup exists. Run 'yokai cloud save' to create one.",
+		})
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	result := map[string]interface{}{
+		"status":             "logged_in",
+		"email":              credentials.Email,
+		"project_id":         credentials.ProjectID,
+		"backup_exists":      true,
+		"backup_updated_at":  metadata.UpdatedAt,
+		"encrypted_size":     metadata.Size,
+		"local_device_count": len(cfg.Devices),
+		"token_expiry":       credentials.Token.Expiry,
+		"message":            "An encrypted cloud backup is available.",
+	}
+	if *verify {
+		passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
+		if err != nil {
+			return err
+		}
+		snapshot, err := cloudsync.Decrypt(envelope, passphrase)
+		if err != nil {
+			return err
+		}
+		result["backup_device_count"] = len(snapshot.Devices)
+		result["verified"] = true
+	}
+	outputJSON(result)
 	return nil
 }
 
@@ -178,6 +420,9 @@ func runCloudDelete(ctx context.Context, args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("cloud delete does not accept positional arguments")
+	}
 	if !*confirmed {
 		return fmt.Errorf("cloud delete is permanent; rerun with --yes")
 	}
@@ -186,17 +431,35 @@ func runCloudDelete(ctx context.Context, args []string) error {
 		return err
 	}
 	if err := client.Delete(ctx); err != nil {
-		return err
+		if !errors.Is(err, cloudsync.ErrNoCloudConfig) {
+			return err
+		}
 	}
-	outputJSON(map[string]interface{}{"status": "deleted", "email": credentials.Email})
+	outputJSON(map[string]interface{}{
+		"status":  "deleted",
+		"email":   credentials.Email,
+		"message": "The encrypted cloud backup was deleted. Local devices were not changed.",
+	})
 	return nil
 }
 
-func runCloudLogout() error {
+func runCloudLogout(args []string) error {
+	flags := flag.NewFlagSet("cloud logout", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	flags.Usage = func() { _, _ = fmt.Fprintln(flags.Output(), "Usage: yokai cloud logout") }
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("cloud logout does not accept positional arguments")
+	}
 	if err := cloudsync.RemoveCredentials(); err != nil {
 		return err
 	}
-	outputJSON(map[string]string{"status": "logged_out"})
+	outputJSON(map[string]string{
+		"status":  "logged_out",
+		"message": "Signed out on this computer. Your encrypted cloud backup was not deleted.",
+	})
 	return nil
 }
 
@@ -221,6 +484,8 @@ func readCloudSavePassphrase() (string, error) {
 	if value := os.Getenv("YOKAI_CLOUD_PASSPHRASE"); value != "" {
 		return value, nil
 	}
+	fmt.Fprintln(os.Stderr, "Create a passphrase with at least 12 characters and save it in a password manager.")
+	fmt.Fprintln(os.Stderr, "Yokai cannot recover a lost cloud passphrase.")
 	passphrase, err := readCloudPassphrase("Cloud encryption passphrase: ")
 	if err != nil {
 		return "", err
@@ -233,6 +498,18 @@ func readCloudSavePassphrase() (string, error) {
 		return "", err
 	}
 	return passphrase, nil
+}
+
+func readCloudConfirmation(reader io.Reader, writer io.Writer, prompt string) (bool, error) {
+	if _, err := fmt.Fprint(writer, prompt); err != nil {
+		return false, fmt.Errorf("writing confirmation prompt: %w", err)
+	}
+	line, err := bufio.NewReader(reader).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fmt.Errorf("reading confirmation: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
 }
 
 func validatePassphraseConfirmation(passphrase, confirmation string) error {

--- a/internal/cli/cloud_test.go
+++ b/internal/cli/cloud_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +15,260 @@ import (
 	"github.com/spencerbull/yokai/internal/cloudsync"
 	"github.com/spencerbull/yokai/internal/config"
 )
+
+func TestCloudSubcommandHelpReturnsBeforeActions(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	credentials := &cloudsync.Credentials{
+		ProjectID: "test-project",
+		APIKey:    "test-key",
+		UID:       "test-user",
+		Token:     cloudsync.StoredToken{RefreshToken: "refresh-token"},
+	}
+	if err := cloudsync.SaveCredentials(credentials); err != nil {
+		t.Fatal(err)
+	}
+	credentialsPath, err := cloudsync.CredentialsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	commands := map[string]func() error{
+		"login":  func() error { return runCloudLogin(context.Background(), []string{"--help"}) },
+		"save":   func() error { return runCloudSave(context.Background(), []string{"--help"}) },
+		"load":   func() error { return runCloudLoad(context.Background(), []string{"--help"}) },
+		"status": func() error { return runCloudStatus(context.Background(), []string{"--help"}) },
+		"delete": func() error { return runCloudDelete(context.Background(), []string{"--help"}) },
+		"logout": func() error { return runCloudLogout([]string{"--help"}) },
+	}
+	for name, run := range commands {
+		if err := run(); !errors.Is(err, flag.ErrHelp) {
+			t.Fatalf("%s --help error = %v", name, err)
+		}
+	}
+	if _, err := os.Stat(credentialsPath); err != nil {
+		t.Fatalf("help mutated cloud credentials: %v", err)
+	}
+	if err := runCloudLogout([]string{"unexpected"}); err == nil {
+		t.Fatal("cloud logout accepted an unexpected argument")
+	}
+	if _, err := os.Stat(credentialsPath); err != nil {
+		t.Fatalf("invalid arguments mutated cloud credentials: %v", err)
+	}
+}
+
+func TestCloudSaveRefusesEmptyDeviceListBeforeLogin(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	err := runCloudSave(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "local config has no devices") {
+		t.Fatalf("runCloudSave() error = %v", err)
+	}
+}
+
+func TestReadCloudConfirmationDefaultsToNo(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		input string
+		want  bool
+	}{
+		{input: "yes\n", want: true},
+		{input: "Y\n", want: true},
+		{input: "\n", want: false},
+		{input: "no\n", want: false},
+	} {
+		var output strings.Builder
+		got, err := readCloudConfirmation(strings.NewReader(test.input), &output, "Continue? ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != test.want {
+			t.Fatalf("confirmation %q = %v, want %v", test.input, got, test.want)
+		}
+		if output.String() != "Continue? " {
+			t.Fatalf("prompt = %q", output.String())
+		}
+	}
+}
+
+type fakeCloudConfigClient struct {
+	getEnvelope cloudsync.Envelope
+	getMetadata cloudsync.Metadata
+	getErr      error
+	putCalls    int
+	putEnvelope cloudsync.Envelope
+}
+
+func (f *fakeCloudConfigClient) Get(context.Context) (cloudsync.Envelope, cloudsync.Metadata, error) {
+	return f.getEnvelope, f.getMetadata, f.getErr
+}
+
+func (f *fakeCloudConfigClient) Put(_ context.Context, envelope cloudsync.Envelope) (cloudsync.Metadata, error) {
+	f.putCalls++
+	f.putEnvelope = envelope
+	return cloudsync.Metadata{UpdatedAt: time.Date(2026, 7, 13, 21, 0, 0, 0, time.UTC)}, nil
+}
+
+func (f *fakeCloudConfigClient) Delete(context.Context) error { return nil }
+
+func testCloudInteraction(input string, terminal bool, passphrase string, outputs *[]interface{}) cloudCommandInteraction {
+	return cloudCommandInteraction{
+		stdin:      strings.NewReader(input),
+		stderr:     &strings.Builder{},
+		isTerminal: terminal,
+		readPassphrase: func(string) (string, error) {
+			return passphrase, nil
+		},
+		readSavePassphrase: func() (string, error) {
+			return passphrase, nil
+		},
+		output: func(value interface{}) {
+			*outputs = append(*outputs, value)
+		},
+	}
+}
+
+func testCloudEnvelope(t *testing.T, devices []config.Device, passphrase string) cloudsync.Envelope {
+	t.Helper()
+	envelope, err := cloudsync.Encrypt(cloudsync.Snapshot{Version: cloudsync.SnapshotVersion, Devices: devices}, passphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return envelope
+}
+
+func TestSaveCloudConfigDoesNotOverwriteOnCancelOrWrongPassphrase(t *testing.T) {
+	const passphrase = "correct test passphrase"
+	existing := testCloudEnvelope(t, []config.Device{{ID: "cloud-device"}}, passphrase)
+	credentials := &cloudsync.Credentials{Email: "user@example.com"}
+	cfg := config.DefaultConfig()
+	cfg.Devices = []config.Device{{ID: "local-device"}}
+
+	t.Run("cancel", func(t *testing.T) {
+		client := &fakeCloudConfigClient{getEnvelope: existing, getMetadata: cloudsync.Metadata{UpdatedAt: time.Now()}}
+		var outputs []interface{}
+		err := saveCloudConfig(context.Background(), client, credentials, cfg, false, testCloudInteraction("n\n", true, passphrase, &outputs))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if client.putCalls != 0 || len(outputs) != 1 {
+			t.Fatalf("cancel putCalls=%d outputs=%#v", client.putCalls, outputs)
+		}
+	})
+
+	t.Run("wrong passphrase", func(t *testing.T) {
+		client := &fakeCloudConfigClient{getEnvelope: existing}
+		var outputs []interface{}
+		err := saveCloudConfig(context.Background(), client, credentials, cfg, true, testCloudInteraction("", false, "incorrect test passphrase", &outputs))
+		if err == nil || client.putCalls != 0 || len(outputs) != 0 {
+			t.Fatalf("wrong passphrase error=%v putCalls=%d outputs=%#v", err, client.putCalls, outputs)
+		}
+	})
+}
+
+func TestSaveCloudConfigConfirmedAndAllowEmptyPaths(t *testing.T) {
+	const passphrase = "correct test passphrase"
+	credentials := &cloudsync.Credentials{Email: "user@example.com"}
+
+	t.Run("confirmed replacement", func(t *testing.T) {
+		existing := testCloudEnvelope(t, []config.Device{{ID: "cloud-device"}}, passphrase)
+		client := &fakeCloudConfigClient{getEnvelope: existing}
+		cfg := config.DefaultConfig()
+		cfg.Devices = []config.Device{{ID: "local-device"}}
+		var outputs []interface{}
+		if err := saveCloudConfig(context.Background(), client, credentials, cfg, true, testCloudInteraction("", false, passphrase, &outputs)); err != nil {
+			t.Fatal(err)
+		}
+		if client.putCalls != 1 || len(outputs) != 1 {
+			t.Fatalf("replacement putCalls=%d outputs=%#v", client.putCalls, outputs)
+		}
+	})
+
+	t.Run("explicit empty backup", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		if err := validateCloudSaveConfig(cfg, false); err == nil {
+			t.Fatal("empty config passed without allow-empty")
+		}
+		if err := validateCloudSaveConfig(cfg, true); err != nil {
+			t.Fatal(err)
+		}
+		client := &fakeCloudConfigClient{getErr: cloudsync.ErrNoCloudConfig}
+		var outputs []interface{}
+		if err := saveCloudConfig(context.Background(), client, credentials, cfg, true, testCloudInteraction("", false, passphrase, &outputs)); err != nil {
+			t.Fatal(err)
+		}
+		if client.putCalls != 1 {
+			t.Fatalf("empty backup putCalls=%d", client.putCalls)
+		}
+	})
+}
+
+func TestLoadCloudConfigDoesNotMutateOnCancelOrWrongPassphrase(t *testing.T) {
+	const passphrase = "correct test passphrase"
+	envelope := testCloudEnvelope(t, []config.Device{{ID: "cloud-device"}}, passphrase)
+	credentials := &cloudsync.Credentials{Email: "user@example.com"}
+	newEffects := func(calls *int) cloudLoadEffects {
+		return cloudLoadEffects{
+			backup: func() (string, error) { (*calls)++; return "backup.json", nil },
+			save:   func(*config.Config) error { (*calls)++; return nil },
+			reload: func(context.Context, *config.Config) bool { (*calls)++; return true },
+		}
+	}
+
+	for _, test := range []struct {
+		name       string
+		confirmed  bool
+		input      string
+		passphrase string
+		wantErr    bool
+	}{
+		{name: "cancel", confirmed: false, input: "n\n", passphrase: passphrase},
+		{name: "wrong passphrase", confirmed: true, passphrase: "incorrect test passphrase", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeCloudConfigClient{getEnvelope: envelope, getMetadata: cloudsync.Metadata{UpdatedAt: time.Now()}}
+			cfg := config.DefaultConfig()
+			cfg.HFToken = "preserve-token"
+			cfg.Devices = []config.Device{{ID: "local-device"}}
+			var outputs []interface{}
+			calls := 0
+			err := loadCloudConfig(context.Background(), client, credentials, cfg, test.confirmed, testCloudInteraction(test.input, true, test.passphrase, &outputs), newEffects(&calls))
+			if (err != nil) != test.wantErr {
+				t.Fatalf("error = %v", err)
+			}
+			if calls != 0 || cfg.Devices[0].ID != "local-device" || cfg.HFToken != "preserve-token" {
+				t.Fatalf("load mutated state: calls=%d cfg=%#v", calls, cfg)
+			}
+		})
+	}
+}
+
+func TestLoadCloudConfigConfirmedPreservesOtherSettings(t *testing.T) {
+	const passphrase = "correct test passphrase"
+	envelope := testCloudEnvelope(t, []config.Device{{ID: "cloud-device"}}, passphrase)
+	client := &fakeCloudConfigClient{getEnvelope: envelope, getMetadata: cloudsync.Metadata{UpdatedAt: time.Now()}}
+	cfg := config.DefaultConfig()
+	cfg.HFToken = "preserve-token"
+	cfg.Services = []config.Service{{ID: "preserve-service"}}
+	cfg.Devices = []config.Device{{ID: "local-device"}}
+	var outputs []interface{}
+	backupCalls, saveCalls, reloadCalls := 0, 0, 0
+	effects := cloudLoadEffects{
+		backup: func() (string, error) { backupCalls++; return "backup.json", nil },
+		save: func(saved *config.Config) error {
+			saveCalls++
+			if saved.HFToken != "preserve-token" || len(saved.Services) != 1 || saved.Devices[0].ID != "cloud-device" {
+				t.Fatalf("saved config = %#v", saved)
+			}
+			return nil
+		},
+		reload: func(context.Context, *config.Config) bool { reloadCalls++; return true },
+	}
+	if err := loadCloudConfig(context.Background(), client, &cloudsync.Credentials{Email: "user@example.com"}, cfg, true, testCloudInteraction("", false, passphrase, &outputs), effects); err != nil {
+		t.Fatal(err)
+	}
+	if backupCalls != 1 || saveCalls != 1 || reloadCalls != 1 || len(outputs) != 1 {
+		t.Fatalf("effects backup=%d save=%d reload=%d outputs=%#v", backupCalls, saveCalls, reloadCalls, outputs)
+	}
+}
 
 func TestValidatePassphraseConfirmation(t *testing.T) {
 	t.Parallel()

--- a/internal/cli/cloud_test.go
+++ b/internal/cli/cloud_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+func TestValidatePassphraseConfirmation(t *testing.T) {
+	t.Parallel()
+	if err := validatePassphraseConfirmation("matching passphrase", "matching passphrase"); err != nil {
+		t.Fatalf("matching passphrases returned error: %v", err)
+	}
+	if err := validatePassphraseConfirmation("first passphrase", "second passphrase"); err == nil {
+		t.Fatal("mismatched passphrases were accepted")
+	}
+}
+
+func TestReloadDaemonWithClientTimesOut(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.Daemon.Listen = strings.TrimPrefix(server.URL, "http://")
+	client := &http.Client{Timeout: 25 * time.Millisecond}
+	started := time.Now()
+	if reloadDaemonWithClient(context.Background(), cfg, client) {
+		t.Fatal("stalled daemon reload unexpectedly succeeded")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("stalled daemon reload took %s", elapsed)
+	}
+}
+
+func TestEnvOrDefault(t *testing.T) {
+	t.Setenv("YOKAI_TEST_DEFAULT", " override ")
+	if got := envOrDefault("YOKAI_TEST_DEFAULT", "fallback"); got != "override" {
+		t.Fatalf("envOrDefault() = %q", got)
+	}
+	t.Setenv("YOKAI_TEST_DEFAULT", "")
+	if got := envOrDefault("YOKAI_TEST_DEFAULT", "fallback"); got != "fallback" {
+		t.Fatalf("envOrDefault() fallback = %q", got)
+	}
+}

--- a/internal/cli/cloud_test.go
+++ b/internal/cli/cloud_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spencerbull/yokai/internal/cloudsync"
 	"github.com/spencerbull/yokai/internal/config"
 )
 
@@ -48,5 +51,66 @@ func TestEnvOrDefault(t *testing.T) {
 	t.Setenv("YOKAI_TEST_DEFAULT", "")
 	if got := envOrDefault("YOKAI_TEST_DEFAULT", "fallback"); got != "fallback" {
 		t.Fatalf("envOrDefault() fallback = %q", got)
+	}
+}
+
+func TestApplyCloudSnapshotPreservesNonDeviceSettings(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	cfg.HFToken = "keep-token"
+	cfg.Services = []config.Service{{ID: "keep-service"}}
+	cfg.Preferences.Theme = "keep-theme"
+	cfg.Devices = []config.Device{{ID: "old-device"}}
+
+	applyCloudSnapshot(cfg, cloudsync.Snapshot{
+		Version: cloudsync.SnapshotVersion,
+		Devices: []config.Device{{ID: "new-device"}},
+	})
+
+	if len(cfg.Devices) != 1 || cfg.Devices[0].ID != "new-device" {
+		t.Fatalf("devices = %#v", cfg.Devices)
+	}
+	if cfg.HFToken != "keep-token" || len(cfg.Services) != 1 || cfg.Services[0].ID != "keep-service" || cfg.Preferences.Theme != "keep-theme" {
+		t.Fatalf("non-device settings changed: %#v", cfg)
+	}
+}
+
+func TestBackupLocalConfigCreatesPrivateExactCopy(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	cfg := config.DefaultConfig()
+	cfg.HFToken = "preserve-me"
+	if err := config.Save(cfg); err != nil {
+		t.Fatal(err)
+	}
+	originalPath, err := config.ConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	backupPath, err := backupLocalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(backupPath) != filepath.Dir(originalPath) {
+		t.Fatalf("backup path = %q", backupPath)
+	}
+	backup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(backup) != string(original) {
+		t.Fatal("backup content differs from original")
+	}
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("backup mode = %o", info.Mode().Perm())
 	}
 }

--- a/internal/cloudsync/client.go
+++ b/internal/cloudsync/client.go
@@ -4,15 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
 const maxResponseSize = 2 << 20
+
+// ErrNoCloudConfig indicates that the signed-in user has not saved a cloud copy.
+var ErrNoCloudConfig = errors.New("no cloud device backup found")
 
 // Client calls Firestore's REST API using a Firebase user ID token.
 type Client struct {
@@ -116,6 +121,9 @@ func (c *Client) do(ctx context.Context, method string, requestBody, responseBod
 		}
 		_ = json.Unmarshal(data, &apiError)
 		message := apiError.Error.Message
+		if resp.StatusCode == http.StatusNotFound && isMissingFirestoreDocument(message) {
+			return fmt.Errorf("%w; run 'yokai cloud save' first", ErrNoCloudConfig)
+		}
 		if message == "" {
 			message = http.StatusText(resp.StatusCode)
 		}
@@ -127,6 +135,14 @@ func (c *Client) do(ctx context.Context, method string, requestBody, responseBod
 		}
 	}
 	return nil
+}
+
+func isMissingFirestoreDocument(message string) bool {
+	message = strings.ToLower(message)
+	if !strings.Contains(message, "document") {
+		return false
+	}
+	return strings.Contains(message, "not found") || strings.Contains(message, "no document") || strings.Contains(message, "document missing")
 }
 
 func envelopeToFields(envelope Envelope) map[string]firestoreValue {

--- a/internal/cloudsync/client.go
+++ b/internal/cloudsync/client.go
@@ -1,0 +1,160 @@
+package cloudsync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const maxResponseSize = 2 << 20
+
+// Client calls Firestore's REST API using a Firebase user ID token.
+type Client struct {
+	documentURL string
+	idToken     string
+	http        *http.Client
+}
+
+// Metadata describes a stored cloud snapshot.
+type Metadata struct {
+	UpdatedAt time.Time `json:"updated_at"`
+	Size      int       `json:"size"`
+}
+
+type firestoreValue struct {
+	IntegerValue string `json:"integerValue,omitempty"`
+	StringValue  string `json:"stringValue,omitempty"`
+}
+
+type firestoreDocument struct {
+	Fields     map[string]firestoreValue `json:"fields"`
+	UpdateTime time.Time                 `json:"updateTime"`
+}
+
+// NewClient loads and refreshes the local Firebase login.
+func NewClient(ctx context.Context) (*Client, *Credentials, error) {
+	credentials, err := LoadCredentials()
+	if err != nil {
+		return nil, nil, err
+	}
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	idToken, err := refreshFirebaseIDToken(ctx, credentials, httpClient)
+	if err != nil {
+		return nil, nil, err
+	}
+	documentURL := "https://firestore.googleapis.com/v1/projects/" + url.PathEscape(credentials.ProjectID) +
+		"/databases/(default)/documents/device_configs/" + url.PathEscape(credentials.UID)
+	return &Client{documentURL: documentURL, idToken: idToken, http: httpClient}, credentials, nil
+}
+
+// Put uploads one encrypted device configuration envelope.
+func (c *Client) Put(ctx context.Context, envelope Envelope) (Metadata, error) {
+	document := firestoreDocument{Fields: envelopeToFields(envelope)}
+	var response firestoreDocument
+	if err := c.do(ctx, http.MethodPatch, document, &response); err != nil {
+		return Metadata{}, err
+	}
+	return Metadata{UpdatedAt: response.UpdateTime, Size: len(envelope.Ciphertext)}, nil
+}
+
+// Get downloads the current encrypted device configuration envelope.
+func (c *Client) Get(ctx context.Context) (Envelope, Metadata, error) {
+	var document firestoreDocument
+	if err := c.do(ctx, http.MethodGet, nil, &document); err != nil {
+		return Envelope{}, Metadata{}, err
+	}
+	envelope, err := fieldsToEnvelope(document.Fields)
+	if err != nil {
+		return Envelope{}, Metadata{}, err
+	}
+	return envelope, Metadata{UpdatedAt: document.UpdateTime, Size: len(envelope.Ciphertext)}, nil
+}
+
+// Delete permanently removes the user's cloud snapshot.
+func (c *Client) Delete(ctx context.Context) error {
+	return c.do(ctx, http.MethodDelete, nil, nil)
+}
+
+func (c *Client) do(ctx context.Context, method string, requestBody, responseBody interface{}) error {
+	var body io.Reader
+	if requestBody != nil {
+		data, err := json.Marshal(requestBody)
+		if err != nil {
+			return fmt.Errorf("encoding Firestore request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.documentURL, body)
+	if err != nil {
+		return fmt.Errorf("creating Firestore request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.idToken)
+	if requestBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling Firestore: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return fmt.Errorf("reading Firestore response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		var apiError struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(data, &apiError)
+		message := apiError.Error.Message
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("firestore: %s", message)
+	}
+	if responseBody != nil && len(data) > 0 {
+		if err := json.Unmarshal(data, responseBody); err != nil {
+			return fmt.Errorf("decoding Firestore response: %w", err)
+		}
+	}
+	return nil
+}
+
+func envelopeToFields(envelope Envelope) map[string]firestoreValue {
+	return map[string]firestoreValue{
+		"version":    {IntegerValue: strconv.Itoa(envelope.Version)},
+		"cipher":     {StringValue: envelope.Cipher},
+		"kdf":        {StringValue: envelope.KDF},
+		"salt":       {StringValue: envelope.Salt},
+		"nonce":      {StringValue: envelope.Nonce},
+		"ciphertext": {StringValue: envelope.Ciphertext},
+	}
+}
+
+func fieldsToEnvelope(fields map[string]firestoreValue) (Envelope, error) {
+	version, err := strconv.Atoi(fields["version"].IntegerValue)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("cloud device config has an invalid version")
+	}
+	envelope := Envelope{
+		Version:    version,
+		Cipher:     fields["cipher"].StringValue,
+		KDF:        fields["kdf"].StringValue,
+		Salt:       fields["salt"].StringValue,
+		Nonce:      fields["nonce"].StringValue,
+		Ciphertext: fields["ciphertext"].StringValue,
+	}
+	if envelope.Cipher == "" || envelope.KDF == "" || envelope.Ciphertext == "" {
+		return Envelope{}, fmt.Errorf("cloud device config is incomplete")
+	}
+	return envelope, nil
+}

--- a/internal/cloudsync/client_test.go
+++ b/internal/cloudsync/client_test.go
@@ -3,8 +3,10 @@ package cloudsync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -55,5 +57,37 @@ func TestFieldsToEnvelopeRejectsIncompleteDocument(t *testing.T) {
 	t.Parallel()
 	if _, err := fieldsToEnvelope(map[string]firestoreValue{}); err == nil {
 		t.Fatal("fieldsToEnvelope() accepted an incomplete document")
+	}
+}
+
+func TestClientGetMapsMissingBackup(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"Document device_configs/test-user not found."}}`))
+	}))
+	defer server.Close()
+
+	client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+	_, _, err := client.Get(context.Background())
+	if !errors.Is(err, ErrNoCloudConfig) {
+		t.Fatalf("Get() error = %v", err)
+	}
+}
+
+func TestClientDoesNotMapBackend404ToMissingBackup(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"Project yokai-missing not found."}}`))
+	}))
+	defer server.Close()
+
+	client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+	_, _, err := client.Get(context.Background())
+	if err == nil || errors.Is(err, ErrNoCloudConfig) || !strings.Contains(err.Error(), "Project yokai-missing") {
+		t.Fatalf("Get() error = %v", err)
 	}
 }

--- a/internal/cloudsync/client_test.go
+++ b/internal/cloudsync/client_test.go
@@ -1,0 +1,59 @@
+package cloudsync
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientPutGetDelete(t *testing.T) {
+	t.Parallel()
+	want := Envelope{Version: 1, Cipher: "aes-256-gcm", KDF: "argon2id-3-65536-4", Salt: "salt", Nonce: "nonce", Ciphertext: "ciphertext"}
+	updatedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer firebase-id-token" {
+			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		switch r.Method {
+		case http.MethodPatch:
+			var document firestoreDocument
+			if err := json.NewDecoder(r.Body).Decode(&document); err != nil {
+				t.Error(err)
+				return
+			}
+			got, err := fieldsToEnvelope(document.Fields)
+			if err != nil || got != want {
+				t.Errorf("PATCH body = %#v, %v", got, err)
+			}
+			_ = json.NewEncoder(w).Encode(firestoreDocument{Fields: document.Fields, UpdateTime: updatedAt})
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(firestoreDocument{Fields: envelopeToFields(want), UpdateTime: updatedAt})
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{documentURL: server.URL + "/config", idToken: "firebase-id-token", http: server.Client()}
+	metadata, err := client.Put(context.Background(), want)
+	if err != nil || !metadata.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("Put() = %#v, %v", metadata, err)
+	}
+	got, metadata, err := client.Get(context.Background())
+	if err != nil || got != want || !metadata.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("Get() = %#v, %#v, %v", got, metadata, err)
+	}
+	if err := client.Delete(context.Background()); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+}
+
+func TestFieldsToEnvelopeRejectsIncompleteDocument(t *testing.T) {
+	t.Parallel()
+	if _, err := fieldsToEnvelope(map[string]firestoreValue{}); err == nil {
+		t.Fatal("fieldsToEnvelope() accepted an incomplete document")
+	}
+}

--- a/internal/cloudsync/credentials.go
+++ b/internal/cloudsync/credentials.go
@@ -1,0 +1,106 @@
+package cloudsync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+const credentialsFile = "cloud-auth.json"
+
+// Credentials contains the Firebase project and refresh token. The file is
+// local-only, mode 0600, and is never part of a synced snapshot.
+type Credentials struct {
+	ProjectID string      `json:"project_id"`
+	APIKey    string      `json:"api_key"`
+	UID       string      `json:"uid"`
+	Email     string      `json:"email,omitempty"`
+	Token     StoredToken `json:"token"`
+}
+
+// StoredToken contains the Firebase ID and refresh tokens used for Firestore.
+type StoredToken struct {
+	IDToken      string    `json:"id_token"`
+	RefreshToken string    `json:"refresh_token"`
+	Expiry       time.Time `json:"expiry"`
+}
+
+// CredentialsPath returns the local cloud credential path.
+func CredentialsPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, credentialsFile), nil
+}
+
+// LoadCredentials loads local Firebase credentials.
+func LoadCredentials() (*Credentials, error) {
+	path, err := CredentialsPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("not logged in; run 'yokai cloud login' first")
+		}
+		return nil, fmt.Errorf("reading cloud credentials: %w", err)
+	}
+	var credentials Credentials
+	if err := json.Unmarshal(data, &credentials); err != nil {
+		return nil, fmt.Errorf("parsing cloud credentials: %w", err)
+	}
+	if credentials.ProjectID == "" || credentials.APIKey == "" || credentials.UID == "" || credentials.Token.RefreshToken == "" {
+		return nil, fmt.Errorf("cloud credentials are incomplete; log in again")
+	}
+	return &credentials, nil
+}
+
+// SaveCredentials atomically writes Firebase credentials with user-only access.
+func SaveCredentials(credentials *Credentials) error {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		return fmt.Errorf("securing config dir: %w", err)
+	}
+	path := filepath.Join(dir, credentialsFile)
+	data, err := json.MarshalIndent(credentials, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling cloud credentials: %w", err)
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("writing cloud credentials: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("saving cloud credentials: %w", err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("securing cloud credentials: %w", err)
+	}
+	return nil
+}
+
+// RemoveCredentials removes the local Firebase credential file.
+func RemoveCredentials() error {
+	path, err := CredentialsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing cloud credentials: %w", err)
+	}
+	return nil
+}

--- a/internal/cloudsync/credentials.go
+++ b/internal/cloudsync/credentials.go
@@ -2,6 +2,7 @@ package cloudsync
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,9 @@ import (
 )
 
 const credentialsFile = "cloud-auth.json"
+
+// ErrNotLoggedIn indicates that this machine does not have usable cloud credentials.
+var ErrNotLoggedIn = errors.New("not logged in")
 
 // Credentials contains the Firebase project and refresh token. The file is
 // local-only, mode 0600, and is never part of a synced snapshot.
@@ -47,7 +51,7 @@ func LoadCredentials() (*Credentials, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("not logged in; run 'yokai cloud login' first")
+			return nil, fmt.Errorf("%w; run 'yokai cloud login' first", ErrNotLoggedIn)
 		}
 		return nil, fmt.Errorf("reading cloud credentials: %w", err)
 	}
@@ -56,7 +60,7 @@ func LoadCredentials() (*Credentials, error) {
 		return nil, fmt.Errorf("parsing cloud credentials: %w", err)
 	}
 	if credentials.ProjectID == "" || credentials.APIKey == "" || credentials.UID == "" || credentials.Token.RefreshToken == "" {
-		return nil, fmt.Errorf("cloud credentials are incomplete; log in again")
+		return nil, fmt.Errorf("%w: cloud credentials are incomplete; run 'yokai cloud login' again", ErrNotLoggedIn)
 	}
 	return &credentials, nil
 }

--- a/internal/cloudsync/credentials.go
+++ b/internal/cloudsync/credentials.go
@@ -79,12 +79,28 @@ func SaveCredentials(credentials *Credentials) error {
 		return fmt.Errorf("marshaling cloud credentials: %w", err)
 	}
 	data = append(data, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
+	tmp, err := os.CreateTemp(dir, ".cloud-auth-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating cloud credential temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("securing cloud credential temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
 		return fmt.Errorf("writing cloud credentials: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing cloud credentials: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing cloud credentials: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("saving cloud credentials: %w", err)
 	}
 	if err := os.Chmod(path, 0600); err != nil {

--- a/internal/cloudsync/credentials_test.go
+++ b/internal/cloudsync/credentials_test.go
@@ -1,11 +1,20 @@
 package cloudsync
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
 	"testing"
 )
+
+func TestLoadCredentialsReportsLoggedOutState(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_, err := LoadCredentials()
+	if !errors.Is(err, ErrNotLoggedIn) {
+		t.Fatalf("LoadCredentials() error = %v", err)
+	}
+}
 
 func TestCredentialsUsePrivatePermissions(t *testing.T) {
 	configHome := t.TempDir()

--- a/internal/cloudsync/credentials_test.go
+++ b/internal/cloudsync/credentials_test.go
@@ -1,0 +1,38 @@
+package cloudsync
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCredentialsUsePrivatePermissions(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	credentials := &Credentials{
+		ProjectID: "yokai-test",
+		APIKey:    "firebase-api-key",
+		UID:       "firebase-user-id",
+		Token:     StoredToken{IDToken: "id-token", RefreshToken: "refresh-token"},
+	}
+	if err := SaveCredentials(credentials); err != nil {
+		t.Fatalf("SaveCredentials() error = %v", err)
+	}
+	path, err := CredentialsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("credential permissions = %o, want 600", got)
+	}
+	loaded, err := LoadCredentials()
+	if err != nil {
+		t.Fatalf("LoadCredentials() error = %v", err)
+	}
+	if loaded.Token.RefreshToken != credentials.Token.RefreshToken {
+		t.Fatal("LoadCredentials() did not preserve refresh token")
+	}
+}

--- a/internal/cloudsync/credentials_test.go
+++ b/internal/cloudsync/credentials_test.go
@@ -1,7 +1,9 @@
 package cloudsync
 
 import (
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 )
 
@@ -34,5 +36,42 @@ func TestCredentialsUsePrivatePermissions(t *testing.T) {
 	}
 	if loaded.Token.RefreshToken != credentials.Token.RefreshToken {
 		t.Fatal("LoadCredentials() did not preserve refresh token")
+	}
+}
+
+func TestConcurrentCredentialSavesRemainAtomic(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	const writers = 16
+	errors := make(chan error, writers)
+	var wait sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			uid := fmt.Sprintf("user-%d", index)
+			errors <- SaveCredentials(&Credentials{
+				ProjectID: "yokai-test",
+				APIKey:    "firebase-api-key",
+				UID:       uid,
+				Token:     StoredToken{IDToken: "id-" + uid, RefreshToken: "refresh-" + uid},
+			})
+		}(i)
+	}
+	wait.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("SaveCredentials() error = %v", err)
+		}
+	}
+
+	loaded, err := LoadCredentials()
+	if err != nil {
+		t.Fatalf("LoadCredentials() error = %v", err)
+	}
+	if loaded.Token.IDToken != "id-"+loaded.UID || loaded.Token.RefreshToken != "refresh-"+loaded.UID {
+		t.Fatalf("credentials contain mixed writes: %#v", loaded)
 	}
 }

--- a/internal/cloudsync/crypto.go
+++ b/internal/cloudsync/crypto.go
@@ -16,6 +16,9 @@ import (
 )
 
 const (
+	// SnapshotVersion is independent from the full local configuration schema.
+	// Increment it only when the portable device payload itself becomes incompatible.
+	SnapshotVersion = 1
 	envelopeVersion = 1
 	keySize         = 32
 	saltSize        = 16
@@ -122,7 +125,7 @@ func Decrypt(envelope Envelope, passphrase string) (Snapshot, error) {
 	if err := json.Unmarshal(plaintext, &snapshot); err != nil {
 		return Snapshot{}, fmt.Errorf("parsing decrypted config: %w", err)
 	}
-	if snapshot.Version != config.ConfigVersion {
+	if snapshot.Version != SnapshotVersion {
 		return Snapshot{}, fmt.Errorf("unsupported device config version %d", snapshot.Version)
 	}
 	if snapshot.Devices == nil {

--- a/internal/cloudsync/crypto.go
+++ b/internal/cloudsync/crypto.go
@@ -1,0 +1,140 @@
+// Package cloudsync encrypts and synchronizes Yokai device configuration.
+package cloudsync
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/argon2"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+const (
+	envelopeVersion = 1
+	keySize         = 32
+	saltSize        = 16
+	argonTime       = 3
+	argonMemoryKiB  = 64 * 1024
+	argonThreads    = 4
+)
+
+// Snapshot is the portable portion of Yokai configuration. Secrets contained
+// in device records are protected by client-side encryption before upload.
+type Snapshot struct {
+	Version int             `json:"version"`
+	Devices []config.Device `json:"devices"`
+}
+
+// Envelope is the encrypted representation stored by the cloud service.
+type Envelope struct {
+	Version    int    `json:"version" firestore:"version"`
+	Cipher     string `json:"cipher" firestore:"cipher"`
+	KDF        string `json:"kdf" firestore:"kdf"`
+	Salt       string `json:"salt" firestore:"salt"`
+	Nonce      string `json:"nonce" firestore:"nonce"`
+	Ciphertext string `json:"ciphertext" firestore:"ciphertext"`
+}
+
+// Encrypt converts a device snapshot to an authenticated AES-256-GCM envelope
+// using an Argon2id key derived from passphrase.
+func Encrypt(snapshot Snapshot, passphrase string) (Envelope, error) {
+	if len(passphrase) < 12 {
+		return Envelope{}, fmt.Errorf("passphrase must contain at least 12 characters")
+	}
+
+	plaintext, err := json.Marshal(snapshot)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("marshaling device snapshot: %w", err)
+	}
+
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return Envelope{}, fmt.Errorf("generating encryption salt: %w", err)
+	}
+
+	key := argon2.IDKey([]byte(passphrase), salt, argonTime, argonMemoryKiB, argonThreads, keySize)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return Envelope{}, fmt.Errorf("creating authenticated cipher: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return Envelope{}, fmt.Errorf("generating encryption nonce: %w", err)
+	}
+
+	additionalData := []byte("yokai-device-config-v1")
+	ciphertext := gcm.Seal(nil, nonce, plaintext, additionalData)
+	return Envelope{
+		Version:    envelopeVersion,
+		Cipher:     "aes-256-gcm",
+		KDF:        "argon2id-3-65536-4",
+		Salt:       base64.RawStdEncoding.EncodeToString(salt),
+		Nonce:      base64.RawStdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
+	}, nil
+}
+
+// Decrypt authenticates and decrypts an envelope into a device snapshot.
+func Decrypt(envelope Envelope, passphrase string) (Snapshot, error) {
+	if envelope.Version != envelopeVersion || envelope.Cipher != "aes-256-gcm" || envelope.KDF != "argon2id-3-65536-4" {
+		return Snapshot{}, fmt.Errorf("unsupported encrypted config format")
+	}
+
+	salt, err := decodeField("salt", envelope.Salt, saltSize)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	nonce, err := decodeField("nonce", envelope.Nonce, 12)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(envelope.Ciphertext)
+	if err != nil || len(ciphertext) < 16 {
+		return Snapshot{}, fmt.Errorf("invalid encrypted config ciphertext")
+	}
+
+	key := argon2.IDKey([]byte(passphrase), salt, argonTime, argonMemoryKiB, argonThreads, keySize)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("creating authenticated cipher: %w", err)
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte("yokai-device-config-v1"))
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("decrypting config: passphrase is incorrect or cloud data was modified")
+	}
+
+	var snapshot Snapshot
+	if err := json.Unmarshal(plaintext, &snapshot); err != nil {
+		return Snapshot{}, fmt.Errorf("parsing decrypted config: %w", err)
+	}
+	if snapshot.Version != config.ConfigVersion {
+		return Snapshot{}, fmt.Errorf("unsupported device config version %d", snapshot.Version)
+	}
+	if snapshot.Devices == nil {
+		snapshot.Devices = []config.Device{}
+	}
+	return snapshot, nil
+}
+
+func decodeField(name, value string, wantLen int) ([]byte, error) {
+	decoded, err := base64.RawStdEncoding.DecodeString(value)
+	if err != nil || len(decoded) != wantLen {
+		return nil, fmt.Errorf("invalid encrypted config %s", name)
+	}
+	return decoded, nil
+}

--- a/internal/cloudsync/crypto_test.go
+++ b/internal/cloudsync/crypto_test.go
@@ -9,7 +9,7 @@ import (
 func TestEncryptDecryptRoundTrip(t *testing.T) {
 	t.Parallel()
 	snapshot := Snapshot{
-		Version: config.ConfigVersion,
+		Version: SnapshotVersion,
 		Devices: []config.Device{{
 			ID:         "finn",
 			Host:       "100.64.0.2",
@@ -36,7 +36,7 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 
 func TestDecryptRejectsWrongPassphraseAndTampering(t *testing.T) {
 	t.Parallel()
-	envelope, err := Encrypt(Snapshot{Version: config.ConfigVersion, Devices: []config.Device{}}, "correct horse battery staple")
+	envelope, err := Encrypt(Snapshot{Version: SnapshotVersion, Devices: []config.Device{}}, "correct horse battery staple")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,6 +47,21 @@ func TestDecryptRejectsWrongPassphraseAndTampering(t *testing.T) {
 	envelope.Ciphertext = envelope.Ciphertext[:len(envelope.Ciphertext)-1] + "A"
 	if _, err := Decrypt(envelope, "correct horse battery staple"); err == nil {
 		t.Fatal("Decrypt() accepted modified ciphertext")
+	}
+}
+
+func TestDecryptSupportsOriginalSnapshotVersion(t *testing.T) {
+	t.Parallel()
+	envelope, err := Encrypt(Snapshot{Version: 1, Devices: []config.Device{{ID: "original"}}}, "correct horse battery staple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := Decrypt(envelope, "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("Decrypt() original snapshot error = %v", err)
+	}
+	if snapshot.Version != 1 || len(snapshot.Devices) != 1 || snapshot.Devices[0].ID != "original" {
+		t.Fatalf("Decrypt() original snapshot = %#v", snapshot)
 	}
 }
 

--- a/internal/cloudsync/crypto_test.go
+++ b/internal/cloudsync/crypto_test.go
@@ -1,0 +1,58 @@
+package cloudsync
+
+import (
+	"testing"
+
+	"github.com/spencerbull/yokai/internal/config"
+)
+
+func TestEncryptDecryptRoundTrip(t *testing.T) {
+	t.Parallel()
+	snapshot := Snapshot{
+		Version: config.ConfigVersion,
+		Devices: []config.Device{{
+			ID:         "finn",
+			Host:       "100.64.0.2",
+			AgentToken: "secret-agent-token",
+			AgentPort:  7474,
+		}},
+	}
+
+	envelope, err := Encrypt(snapshot, "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+	if envelope.Ciphertext == "" || envelope.Ciphertext == "secret-agent-token" {
+		t.Fatal("Encrypt() did not produce ciphertext")
+	}
+	decrypted, err := Decrypt(envelope, "correct horse battery staple")
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+	if len(decrypted.Devices) != 1 || decrypted.Devices[0].AgentToken != "secret-agent-token" {
+		t.Fatalf("Decrypt() = %#v", decrypted)
+	}
+}
+
+func TestDecryptRejectsWrongPassphraseAndTampering(t *testing.T) {
+	t.Parallel()
+	envelope, err := Encrypt(Snapshot{Version: config.ConfigVersion, Devices: []config.Device{}}, "correct horse battery staple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decrypt(envelope, "wrong passphrase value"); err == nil {
+		t.Fatal("Decrypt() accepted wrong passphrase")
+	}
+
+	envelope.Ciphertext = envelope.Ciphertext[:len(envelope.Ciphertext)-1] + "A"
+	if _, err := Decrypt(envelope, "correct horse battery staple"); err == nil {
+		t.Fatal("Decrypt() accepted modified ciphertext")
+	}
+}
+
+func TestEncryptRequiresStrongPassphrase(t *testing.T) {
+	t.Parallel()
+	if _, err := Encrypt(Snapshot{}, "too-short"); err == nil {
+		t.Fatal("Encrypt() accepted a short passphrase")
+	}
+}

--- a/internal/cloudsync/defaults.go
+++ b/internal/cloudsync/defaults.go
@@ -1,0 +1,11 @@
+package cloudsync
+
+// Public deployment defaults. Firebase API keys and desktop OAuth client
+// credentials identify the application; Firestore Security Rules authorize
+// access. OAuth values are injected into release builds with Go linker flags.
+var (
+	DefaultProjectID          = "yokai-config-260709-5820"
+	DefaultAPIKey             = "AIzaSyCzqb4u5v4Dp-EucLI1F3HW3UnuXzvYmeI"
+	DefaultGoogleClientID     string
+	DefaultGoogleClientSecret string
+)

--- a/internal/cloudsync/oauth.go
+++ b/internal/cloudsync/oauth.go
@@ -1,0 +1,313 @@
+package cloudsync
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+const firebaseAuthTimeout = 30 * time.Second
+
+// LoginOptions configures Google OAuth and Firebase Authentication.
+type LoginOptions struct {
+	ProjectID          string
+	APIKey             string
+	GoogleClientID     string
+	GoogleClientSecret string
+	OpenURL            func(string) error
+	AnnounceURL        func(string)
+	HTTPClient         *http.Client
+}
+
+// Login signs in with Google using the desktop loopback flow and exchanges the
+// Google ID token for a narrow Firebase session used only by this project.
+func Login(ctx context.Context, options LoginOptions) (*Credentials, error) {
+	if err := validateLoginOptions(options); err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("starting OAuth callback listener: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	redirectURL := "http://" + listener.Addr().String() + "/oauth/callback"
+	conf := oauthConfig(options.GoogleClientID, options.GoogleClientSecret, redirectURL)
+	state, err := randomURLToken(32)
+	if err != nil {
+		return nil, err
+	}
+	verifier := oauth2.GenerateVerifier()
+	authURL := conf.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier), oauth2.SetAuthURLParam("prompt", "select_account"))
+
+	type callbackResult struct {
+		code string
+		err  error
+	}
+	callback := make(chan callbackResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /oauth/callback", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			http.Error(w, "invalid OAuth state", http.StatusBadRequest)
+			callback <- callbackResult{err: fmt.Errorf("OAuth callback state did not match")}
+			return
+		}
+		if oauthErr := r.URL.Query().Get("error"); oauthErr != "" {
+			http.Error(w, "Google login was not completed", http.StatusBadRequest)
+			callback <- callbackResult{err: fmt.Errorf("google login failed: %s", oauthErr)}
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "missing authorization code", http.StatusBadRequest)
+			callback <- callbackResult{err: fmt.Errorf("OAuth callback did not include a code")}
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<!doctype html><title>Yokai login complete</title><p>Yokai is connected. You can close this window.</p>"))
+		callback <- callbackResult{code: code}
+	})
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = server.Serve(listener) }()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	if options.AnnounceURL != nil {
+		options.AnnounceURL(authURL)
+	}
+	opener := options.OpenURL
+	if opener == nil {
+		opener = openBrowser
+	}
+	if err := opener(authURL); err != nil && options.AnnounceURL == nil {
+		return nil, fmt.Errorf("opening browser: %w", err)
+	}
+
+	var result callbackResult
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("waiting for Google login: %w", ctx.Err())
+	case result = <-callback:
+	}
+	if result.err != nil {
+		return nil, result.err
+	}
+
+	googleToken, err := conf.Exchange(ctx, result.code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return nil, fmt.Errorf("exchanging Google authorization code: %w", err)
+	}
+	googleIDToken, _ := googleToken.Extra("id_token").(string)
+	if googleIDToken == "" {
+		return nil, fmt.Errorf("google did not return an ID token")
+	}
+
+	firebaseToken, err := exchangeFirebaseToken(ctx, options, googleIDToken)
+	if err != nil {
+		return nil, err
+	}
+	credentials := &Credentials{
+		ProjectID: options.ProjectID,
+		APIKey:    options.APIKey,
+		UID:       firebaseToken.LocalID,
+		Email:     firebaseToken.Email,
+		Token: StoredToken{
+			IDToken:      firebaseToken.IDToken,
+			RefreshToken: firebaseToken.RefreshToken,
+			Expiry:       time.Now().Add(firebaseToken.expiresIn()),
+		},
+	}
+	if err := SaveCredentials(credentials); err != nil {
+		return nil, err
+	}
+	return credentials, nil
+}
+
+type firebaseSignInResponse struct {
+	IDToken      string `json:"idToken"`
+	RefreshToken string `json:"refreshToken"`
+	ExpiresIn    string `json:"expiresIn"`
+	LocalID      string `json:"localId"`
+	Email        string `json:"email"`
+}
+
+func (r firebaseSignInResponse) expiresIn() time.Duration {
+	seconds, err := strconv.Atoi(r.ExpiresIn)
+	if err != nil || seconds < 1 {
+		return time.Hour
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func exchangeFirebaseToken(ctx context.Context, options LoginOptions, googleIDToken string) (firebaseSignInResponse, error) {
+	payload := map[string]interface{}{
+		"postBody":            "id_token=" + url.QueryEscape(googleIDToken) + "&providerId=google.com",
+		"requestUri":          "https://" + options.ProjectID + ".firebaseapp.com/__/auth/handler",
+		"returnIdpCredential": true,
+		"returnSecureToken":   true,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return firebaseSignInResponse{}, fmt.Errorf("encoding Firebase sign-in: %w", err)
+	}
+	requestURL := "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=" + url.QueryEscape(options.APIKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(data))
+	if err != nil {
+		return firebaseSignInResponse{}, fmt.Errorf("creating Firebase sign-in request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := options.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: firebaseAuthTimeout}
+	}
+	var response firebaseSignInResponse
+	if err := doFirebaseAuthRequest(client, req, &response); err != nil {
+		return firebaseSignInResponse{}, err
+	}
+	if response.IDToken == "" || response.RefreshToken == "" || response.LocalID == "" {
+		return firebaseSignInResponse{}, fmt.Errorf("firebase sign-in response was incomplete")
+	}
+	return response, nil
+}
+
+func refreshFirebaseIDToken(ctx context.Context, credentials *Credentials, client *http.Client) (string, error) {
+	if credentials.Token.IDToken != "" && credentials.Token.Expiry.After(time.Now().Add(5*time.Minute)) {
+		return credentials.Token.IDToken, nil
+	}
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {credentials.Token.RefreshToken},
+	}
+	requestURL := "https://securetoken.googleapis.com/v1/token?key=" + url.QueryEscape(credentials.APIKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("creating Firebase refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if client == nil {
+		client = &http.Client{Timeout: firebaseAuthTimeout}
+	}
+	var response struct {
+		IDToken      string `json:"id_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    string `json:"expires_in"`
+		UserID       string `json:"user_id"`
+	}
+	if err := doFirebaseAuthRequest(client, req, &response); err != nil {
+		return "", fmt.Errorf("refreshing Firebase login: %w", err)
+	}
+	if response.IDToken == "" || response.RefreshToken == "" || response.UserID != credentials.UID {
+		return "", fmt.Errorf("firebase refresh response was incomplete or changed user")
+	}
+	seconds, _ := strconv.Atoi(response.ExpiresIn)
+	if seconds < 1 {
+		seconds = 3600
+	}
+	credentials.Token = StoredToken{
+		IDToken:      response.IDToken,
+		RefreshToken: response.RefreshToken,
+		Expiry:       time.Now().Add(time.Duration(seconds) * time.Second),
+	}
+	if err := SaveCredentials(credentials); err != nil {
+		return "", err
+	}
+	return response.IDToken, nil
+}
+
+func doFirebaseAuthRequest(client *http.Client, req *http.Request, result interface{}) error {
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling Firebase Authentication: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("reading Firebase Authentication response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		var apiError struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(data, &apiError)
+		message := apiError.Error.Message
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return fmt.Errorf("firebase authentication: %s", message)
+	}
+	if err := json.Unmarshal(data, result); err != nil {
+		return fmt.Errorf("decoding Firebase Authentication response: %w", err)
+	}
+	return nil
+}
+
+func oauthConfig(clientID, clientSecret, redirectURL string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       []string{"openid", "email"},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://accounts.google.com/o/oauth2/v2/auth",
+			TokenURL: "https://oauth2.googleapis.com/token",
+		},
+	}
+}
+
+func validateLoginOptions(options LoginOptions) error {
+	if strings.TrimSpace(options.ProjectID) == "" || strings.TrimSpace(options.APIKey) == "" {
+		return fmt.Errorf("firebase project ID and API key are required")
+	}
+	if strings.ContainsAny(options.ProjectID, "/?#") {
+		return fmt.Errorf("firebase project ID is invalid")
+	}
+	if strings.TrimSpace(options.GoogleClientID) == "" || strings.TrimSpace(options.GoogleClientSecret) == "" {
+		return fmt.Errorf("google OAuth client ID and client secret are required")
+	}
+	return nil
+}
+
+func randomURLToken(size int) (string, error) {
+	b := make([]byte, size)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating OAuth state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func openBrowser(targetURL string) error {
+	var command string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		command = "open"
+		args = []string{targetURL}
+	case "windows":
+		command = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", targetURL}
+	default:
+		command = "xdg-open"
+		args = []string{targetURL}
+	}
+	return exec.Command(command, args...).Start()
+}

--- a/internal/cloudsync/oauth.go
+++ b/internal/cloudsync/oauth.go
@@ -21,7 +21,10 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const firebaseAuthTimeout = 30 * time.Second
+const (
+	firebaseAuthTimeout = 30 * time.Second
+	browserOpenGrace    = 100 * time.Millisecond
+)
 
 type oauthCallbackResult struct {
 	code string
@@ -76,15 +79,25 @@ func Login(ctx context.Context, options LoginOptions) (*Credentials, error) {
 		_ = server.Shutdown(shutdownCtx)
 	}()
 
-	if options.AnnounceURL != nil {
-		options.AnnounceURL(authURL)
-	}
 	opener := options.OpenURL
 	if opener == nil {
 		opener = openBrowser
 	}
-	if err := opener(authURL); err != nil && options.AnnounceURL == nil {
-		return nil, fmt.Errorf("opening browser: %w", err)
+	if options.AnnounceURL != nil {
+		options.AnnounceURL(authURL)
+	}
+	openResult := make(chan error, 1)
+	go func() { openResult <- opener(authURL) }()
+	select {
+	case err := <-openResult:
+		if err != nil && options.AnnounceURL == nil {
+			return nil, fmt.Errorf("opening browser: %w", err)
+		}
+	case <-time.After(browserOpenGrace):
+		// Some desktop launchers remain attached to the browser. Continue waiting
+		// for the OAuth callback rather than letting the launcher block login.
+	case <-ctx.Done():
+		return nil, fmt.Errorf("opening browser: %w", ctx.Err())
 	}
 
 	var result oauthCallbackResult
@@ -145,7 +158,25 @@ func oauthCallbackHandler(state string, complete func(oauthCallbackResult)) http
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write([]byte("<!doctype html><title>Yokai login complete</title><p>Yokai is connected. You can close this window.</p>"))
+		_, _ = w.Write([]byte(`<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Return to Yokai</title>
+<style>
+  :root { color-scheme: dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #0f172a; color: #f8fafc; }
+  main { width: min(34rem, calc(100% - 3rem)); padding: 2.25rem; border: 1px solid #334155; border-radius: 1rem; background: #111827; }
+  .mark { color: #60a5fa; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+  h1 { margin: .75rem 0; font-size: 1.75rem; }
+  p { margin: 0; color: #cbd5e1; line-height: 1.6; }
+</style>
+<main>
+  <div class="mark">Yokai</div>
+  <h1>Google authorization received</h1>
+  <p>Return to Yokai while it finishes connecting. You can close this tab.</p>
+</main>
+</html>`))
 		complete(oauthCallbackResult{code: code})
 	})
 }

--- a/internal/cloudsync/oauth.go
+++ b/internal/cloudsync/oauth.go
@@ -15,12 +15,18 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
 )
 
 const firebaseAuthTimeout = 30 * time.Second
+
+type oauthCallbackResult struct {
+	code string
+	err  error
+}
 
 // LoginOptions configures Google OAuth and Firebase Authentication.
 type LoginOptions struct {
@@ -55,33 +61,13 @@ func Login(ctx context.Context, options LoginOptions) (*Credentials, error) {
 	verifier := oauth2.GenerateVerifier()
 	authURL := conf.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier), oauth2.SetAuthURLParam("prompt", "select_account"))
 
-	type callbackResult struct {
-		code string
-		err  error
+	callback := make(chan oauthCallbackResult, 1)
+	var callbackOnce sync.Once
+	completeCallback := func(result oauthCallbackResult) {
+		callbackOnce.Do(func() { callback <- result })
 	}
-	callback := make(chan callbackResult, 1)
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /oauth/callback", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("state") != state {
-			http.Error(w, "invalid OAuth state", http.StatusBadRequest)
-			callback <- callbackResult{err: fmt.Errorf("OAuth callback state did not match")}
-			return
-		}
-		if oauthErr := r.URL.Query().Get("error"); oauthErr != "" {
-			http.Error(w, "Google login was not completed", http.StatusBadRequest)
-			callback <- callbackResult{err: fmt.Errorf("google login failed: %s", oauthErr)}
-			return
-		}
-		code := r.URL.Query().Get("code")
-		if code == "" {
-			http.Error(w, "missing authorization code", http.StatusBadRequest)
-			callback <- callbackResult{err: fmt.Errorf("OAuth callback did not include a code")}
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write([]byte("<!doctype html><title>Yokai login complete</title><p>Yokai is connected. You can close this window.</p>"))
-		callback <- callbackResult{code: code}
-	})
+	mux.Handle("GET /oauth/callback", oauthCallbackHandler(state, completeCallback))
 	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	go func() { _ = server.Serve(listener) }()
 	defer func() {
@@ -101,7 +87,7 @@ func Login(ctx context.Context, options LoginOptions) (*Credentials, error) {
 		return nil, fmt.Errorf("opening browser: %w", err)
 	}
 
-	var result callbackResult
+	var result oauthCallbackResult
 	select {
 	case <-ctx.Done():
 		return nil, fmt.Errorf("waiting for Google login: %w", ctx.Err())
@@ -139,6 +125,29 @@ func Login(ctx context.Context, options LoginOptions) (*Credentials, error) {
 		return nil, err
 	}
 	return credentials, nil
+}
+
+func oauthCallbackHandler(state string, complete func(oauthCallbackResult)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			http.Error(w, "invalid OAuth state", http.StatusBadRequest)
+			return
+		}
+		if oauthErr := r.URL.Query().Get("error"); oauthErr != "" {
+			http.Error(w, "Google login was not completed", http.StatusBadRequest)
+			complete(oauthCallbackResult{err: fmt.Errorf("google login failed: %s", oauthErr)})
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "missing authorization code", http.StatusBadRequest)
+			complete(oauthCallbackResult{err: fmt.Errorf("OAuth callback did not include a code")})
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<!doctype html><title>Yokai login complete</title><p>Yokai is connected. You can close this window.</p>"))
+		complete(oauthCallbackResult{code: code})
+	})
 }
 
 type firebaseSignInResponse struct {

--- a/internal/cloudsync/oauth_test.go
+++ b/internal/cloudsync/oauth_test.go
@@ -39,6 +39,9 @@ func TestOAuthCallbackIgnoresInvalidState(t *testing.T) {
 	if valid.Code != http.StatusOK {
 		t.Fatalf("valid state status = %d", valid.Code)
 	}
+	if body := valid.Body.String(); !strings.Contains(body, "Google authorization received") || !strings.Contains(body, "Return to Yokai") {
+		t.Fatalf("valid callback body = %q", body)
+	}
 	select {
 	case result := <-results:
 		if result.code != "valid-code" || result.err != nil {
@@ -109,5 +112,37 @@ func TestRefreshFirebaseIDTokenReusesFreshToken(t *testing.T) {
 	})})
 	if err != nil || got != "fresh-token" {
 		t.Fatalf("refreshFirebaseIDToken() = %q, %v", got, err)
+	}
+}
+
+func TestLoginBlockingBrowserOpenerHonorsContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	release := make(chan struct{})
+	defer close(release)
+	announced := make(chan struct{}, 1)
+	started := time.Now()
+	_, err := Login(ctx, LoginOptions{
+		ProjectID:          "yokai-test",
+		APIKey:             "public-api-key",
+		GoogleClientID:     "client-id",
+		GoogleClientSecret: "client-secret",
+		OpenURL: func(string) error {
+			<-release
+			return nil
+		},
+		AnnounceURL: func(string) { announced <- struct{}{} },
+	})
+	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Fatalf("Login() error = %v", err)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatalf("blocking opener held login for %s", time.Since(started))
+	}
+	select {
+	case <-announced:
+	default:
+		t.Fatal("fallback URL was not announced")
 	}
 }

--- a/internal/cloudsync/oauth_test.go
+++ b/internal/cloudsync/oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,39 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return f(request)
+}
+
+func TestOAuthCallbackIgnoresInvalidState(t *testing.T) {
+	t.Parallel()
+	results := make(chan oauthCallbackResult, 1)
+	handler := oauthCallbackHandler("expected-state", func(result oauthCallbackResult) {
+		results <- result
+	})
+
+	invalid := httptest.NewRecorder()
+	handler.ServeHTTP(invalid, httptest.NewRequest(http.MethodGet, "/oauth/callback?state=wrong&code=attacker", nil))
+	if invalid.Code != http.StatusBadRequest {
+		t.Fatalf("invalid state status = %d", invalid.Code)
+	}
+	select {
+	case result := <-results:
+		t.Fatalf("invalid state completed callback: %#v", result)
+	default:
+	}
+
+	valid := httptest.NewRecorder()
+	handler.ServeHTTP(valid, httptest.NewRequest(http.MethodGet, "/oauth/callback?state=expected-state&code=valid-code", nil))
+	if valid.Code != http.StatusOK {
+		t.Fatalf("valid state status = %d", valid.Code)
+	}
+	select {
+	case result := <-results:
+		if result.code != "valid-code" || result.err != nil {
+			t.Fatalf("valid callback result = %#v", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("valid callback did not complete")
+	}
 }
 
 func TestRefreshFirebaseIDToken(t *testing.T) {

--- a/internal/cloudsync/oauth_test.go
+++ b/internal/cloudsync/oauth_test.go
@@ -1,0 +1,79 @@
+package cloudsync
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestRefreshFirebaseIDToken(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	credentials := &Credentials{
+		ProjectID: "yokai-test",
+		APIKey:    "public-api-key",
+		UID:       "user-123",
+		Token: StoredToken{
+			IDToken:      "expired-token",
+			RefreshToken: "old-refresh-token",
+			Expiry:       time.Now().Add(-time.Hour),
+		},
+	}
+	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost || !strings.Contains(request.URL.String(), "securetoken.googleapis.com/v1/token?key=public-api-key") {
+			t.Errorf("request = %s %s", request.Method, request.URL)
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), "refresh_token=old-refresh-token") {
+			t.Errorf("body = %q", body)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(`{
+              "id_token":"new-id-token",
+              "refresh_token":"new-refresh-token",
+              "expires_in":"3600",
+              "user_id":"user-123"
+            }`)),
+		}, nil
+	})}
+
+	got, err := refreshFirebaseIDToken(context.Background(), credentials, client)
+	if err != nil {
+		t.Fatalf("refreshFirebaseIDToken() error = %v", err)
+	}
+	if got != "new-id-token" || credentials.Token.RefreshToken != "new-refresh-token" {
+		t.Fatalf("refreshed credentials = %#v", credentials.Token)
+	}
+	loaded, err := LoadCredentials()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Token.IDToken != "new-id-token" {
+		t.Fatal("refreshed token was not persisted")
+	}
+}
+
+func TestRefreshFirebaseIDTokenReusesFreshToken(t *testing.T) {
+	t.Parallel()
+	credentials := &Credentials{Token: StoredToken{IDToken: "fresh-token", Expiry: time.Now().Add(time.Hour)}}
+	got, err := refreshFirebaseIDToken(context.Background(), credentials, &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		t.Fatal("fresh token should not make a request")
+		return nil, nil
+	})})
+	if err != nil || got != "fresh-token" {
+		t.Fatalf("refreshFirebaseIDToken() = %q, %v", got, err)
+	}
+}

--- a/tests/firebase/firestore.rules.test.mjs
+++ b/tests/firebase/firestore.rules.test.mjs
@@ -1,0 +1,86 @@
+import { after, before, beforeEach, test } from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from "@firebase/rules-unit-testing"
+import { deleteDoc, doc, getDoc, setDoc } from "firebase/firestore"
+
+const projectId = "demo-yokai"
+const rulesPath = fileURLToPath(new URL("../../firestore.rules", import.meta.url))
+const validEnvelope = {
+  version: 1,
+  cipher: "aes-256-gcm",
+  kdf: "argon2id-3-65536-4",
+  salt: "AAAAAAAAAAAAAAAAAAAAAA",
+  nonce: "AAAAAAAAAAAAAAAA",
+  ciphertext: "encrypted-device-config",
+}
+
+let testEnvironment
+
+before(async () => {
+  testEnvironment = await initializeTestEnvironment({
+    projectId,
+    firestore: {
+      rules: readFileSync(rulesPath, "utf8"),
+      host: "127.0.0.1",
+      port: 8080,
+    },
+  })
+})
+
+beforeEach(async () => {
+  await testEnvironment.clearFirestore()
+})
+
+after(async () => {
+  await testEnvironment.cleanup()
+})
+
+test("an authenticated user can create, read, and delete their encrypted config", async () => {
+  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+  const config = doc(owner, "device_configs", "owner-user")
+
+  await assertSucceeds(setDoc(config, validEnvelope))
+  const snapshot = await assertSucceeds(getDoc(config))
+  assert.equal(snapshot.data().cipher, "aes-256-gcm")
+  await assertSucceeds(deleteDoc(config))
+})
+
+test("another user cannot read, overwrite, or delete an owner's config", async () => {
+  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+  await assertSucceeds(setDoc(doc(owner, "device_configs", "owner-user"), validEnvelope))
+
+  const intruder = testEnvironment.authenticatedContext("intruder-user").firestore()
+  const target = doc(intruder, "device_configs", "owner-user")
+  await assertFails(getDoc(target))
+  await assertFails(setDoc(target, validEnvelope))
+  await assertFails(deleteDoc(target))
+})
+
+test("unauthenticated clients cannot access cloud configs", async () => {
+  const anonymous = testEnvironment.unauthenticatedContext().firestore()
+  const target = doc(anonymous, "device_configs", "owner-user")
+  await assertFails(getDoc(target))
+  await assertFails(setDoc(target, validEnvelope))
+})
+
+test("rules reject plaintext, unexpected fields, and oversized ciphertext", async () => {
+  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+  const target = doc(owner, "device_configs", "owner-user")
+
+  await assertFails(setDoc(target, { ...validEnvelope, cipher: "plaintext" }))
+  await assertFails(setDoc(target, { ...validEnvelope, email: "leak@example.com" }))
+  await assertFails(setDoc(target, { ...validEnvelope, ciphertext: "A".repeat(900001) }))
+})
+
+test("an authenticated user cannot write outside their UID document", async () => {
+  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+  await assertFails(setDoc(doc(owner, "device_configs", "different-user"), validEnvelope))
+  await assertFails(setDoc(doc(owner, "other_collection", "owner-user"), validEnvelope))
+})

--- a/tests/firebase/package-lock.json
+++ b/tests/firebase/package-lock.json
@@ -1,0 +1,1184 @@
+{
+  "name": "yokai-firebase-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yokai-firebase-tests",
+      "devDependencies": {
+        "@firebase/rules-unit-testing": "^5.0.0",
+        "firebase": "^12.0.0"
+      }
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
+      "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
+      "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.15.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^0.4.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.5",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+      "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
+      "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
+      "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.1.tgz",
+      "integrity": "sha512-EvbxUvgoY2cG7vgtdhKc7gjalKzeO3AWr2NiUuyEEmcXaSaOJanV3hXLj3Viigs+Y/jFYQmtVPpSoiwUs/ZlPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
+      "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.13.1",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.15.1",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-compat": "0.4.5",
+        "@firebase/app-compat": "0.5.15",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-compat": "0.6.8",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-compat": "0.4.11",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-compat": "0.2.27",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/tests/firebase/package.json
+++ b/tests/firebase/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "yokai-firebase-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "firebase emulators:exec --only firestore --project demo-yokai --config ../../firebase.json \"node --test --test-concurrency=1 firestore.rules.test.mjs\""
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.0",
+    "firebase": "^12.0.0"
+  }
+}

--- a/tests/scripts/setup-common.test.sh
+++ b/tests/scripts/setup-common.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../../deploy/gcp/setup-common.sh
+source "${REPO_ROOT}/deploy/gcp/setup-common.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+gcloud() { return 1; }
+if verify_spark_billing test-project 0 2>/dev/null; then
+  fail 'billing lookup failure was accepted'
+fi
+
+gcloud() { printf 'True\n'; }
+if verify_spark_billing test-project 0 2>/dev/null; then
+  fail 'billed project was accepted without override'
+fi
+verify_spark_billing test-project 1 || fail 'explicit billed-project override was rejected'
+
+gcloud() { printf 'False\n'; }
+verify_spark_billing test-project 0 || fail 'unbilled project was rejected'
+
+apps='{"result":[{"appId":"unrelated","displayName":"Other App"},{"appId":"wanted","displayName":"Yokai CLI development"}]}'
+[[ "$(firebase_app_id "${apps}" 'Yokai CLI development')" == "wanted" ]] || fail 'selected the wrong Firebase app'
+
+duplicates='{"result":[{"appId":"one","displayName":"Yokai CLI development"},{"appId":"two","displayName":"Yokai CLI development"}]}'
+if firebase_app_id "${duplicates}" 'Yokai CLI development' >/dev/null 2>&1; then
+  fail 'duplicate Firebase apps were accepted'
+fi
+
+printf 'setup-common tests passed\n'


### PR DESCRIPTION
## What changed

- add `yokai cloud login|save|load|status|delete|logout`
- authenticate users with Google through Firebase Authentication
- encrypt device records client-side with Argon2id and AES-256-GCM before writing to Firestore
- preserve non-device settings and create a timestamped local backup before cloud loads
- add owner-only Firestore Security Rules and emulator coverage
- add isolated Firebase development, staging, and production deployment targets
- map `develop`, `staging`, and `main` to matching protected GitHub Environments
- add per-project keyless GitHub Actions deployment through workload identity federation
- add reproducible long-lived branch governance and promotion documentation

## Environment and promotion model

| Branch | GitHub Environment | Firebase project | Promotion |
|---|---|---|---|
| `develop` | `firebase-development` | `yokai-config-dev-260709-5820` | feature PRs |
| `staging` | `firebase-staging` | `yokai-config-stg-260709-5820` | PR from `develop` |
| `main` | `firebase-production` | `yokai-config-260709-5820` | PR from `staging` + production approval |

All three long-lived branches require pull requests, the five CI contexts, resolved review threads, and `@spencerbull` code-owner approval. Direct pushes, force pushes, and deletion are blocked. Spencer can bypass approval only while merging a PR, not by direct push.

## Why

Yokai device configs contain private hosts, SSH metadata, and agent tokens. Separate unbilled Firebase Spark projects prevent development and staging data, users, quotas, API keys, and deployment identities from touching production. Client-side encryption keeps plaintext and passphrases off every backend.

## Current infrastructure state

- Production is unbilled, delete-protected, keyless, least-privilege, and populated with environment-scoped GitHub variables.
- Development and staging branches/GitHub Environments are live and branch-restricted.
- Google Cloud rejected creation of the two pre-production projects because the account has reached its project-count quota. Their environment variables intentionally remain empty until two additional non-billable project slots are approved.

## Validation

- all 10 GitHub checks pass across push and PR runs
- Go race tests and golangci-lint pass for the changed packages
- Firestore emulator: 5/5 security scenarios pass
- OpenTUI: 23/23 tests, bundle build, and standalone compile pass
- snapshot release builds and all five archives pass
- Actionlint, ShellCheck, Bash syntax checks, and `git diff --check` pass
- production OIDC claims, custom IAM role, environment values, billing state, delete protection, and absence of service-account keys verified live
