### PR TITLE
fix: show Yokai home before onboarding

### DIFF
--- a/ui/tui/src/app/App.tsx
+++ b/ui/tui/src/app/App.tsx
@@ -19,8 +19,7 @@ import { keymapForRoute } from "./keymap"
 import { APP_ROUTES, type AppRouteId } from "./routes"
 import { getShellContentHeight, getShellContentWidth } from "./shell/layout"
 import { ShellFrame } from "./shell/ShellFrame"
-
-type AppMode = "home" | "app"
+import { resolveAppSurface, type AppMode } from "./surface"
 
 export function App() {
   return (
@@ -42,8 +41,9 @@ function AppShell() {
   const [exitArmed, setExitArmed] = useState<null | "ctrlc" | "escape">(null)
   const dashboard = useDashboardController(activeRoute === "dashboard", width, height)
   const devices = useDevicesController(true)
-  const onboardingVisible = devices.status !== "ready" || devices.devices.length === 0
-  const homeVisible = !onboardingVisible && appMode === "home"
+  const surface = resolveAppSurface(appMode, devices.status, devices.devices.length)
+  const onboardingVisible = surface === "onboarding"
+  const homeVisible = surface === "home"
   const deploy = useDeployController(activeRoute === "deploy" && !onboardingVisible, () => setActiveRoute("dashboard"))
   const settings = useSettingsController(activeRoute === "settings" && !onboardingVisible, theme)
 
@@ -83,7 +83,7 @@ function AppShell() {
       }
     }
 
-    if (!onboardingVisible && key.name === "g") {
+    if (!homeVisible && key.name === "g") {
       activateHome()
       return
     }
@@ -182,9 +182,7 @@ function AppShell() {
 
   const active = APP_ROUTES.find((route) => route.id === activeRoute) ?? APP_ROUTES[0]
   const mainContent =
-    onboardingVisible ? (
-      <OnboardingRoute contentWidth={contentWidth} controller={devices} />
-    ) : homeVisible ? (
+    homeVisible ? (
       <LandingRoute
         onActivate={activateRoute}
         onSelectIndex={setLandingIndex}
@@ -193,6 +191,8 @@ function AppShell() {
         terminalHeight={height}
         terminalWidth={width}
       />
+    ) : onboardingVisible ? (
+      <OnboardingRoute contentWidth={contentWidth} controller={devices} />
     ) : activeRoute === "dashboard" ? (
       <DashboardRoute contentHeight={contentHeight} contentWidth={contentWidth} controller={dashboard} terminalHeight={height} />
     ) : activeRoute === "devices" ? (

--- a/ui/tui/src/app/surface.test.ts
+++ b/ui/tui/src/app/surface.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolveAppSurface } from "./surface"
+
+describe("resolveAppSurface", () => {
+  test("shows the Yokai home screen before devices are configured", () => {
+    expect(resolveAppSurface("home", "loading", 0)).toBe("home")
+    expect(resolveAppSurface("home", "ready", 0)).toBe("home")
+  })
+
+  test("opens onboarding after selecting a route without devices", () => {
+    expect(resolveAppSurface("app", "loading", 0)).toBe("onboarding")
+    expect(resolveAppSurface("app", "ready", 0)).toBe("onboarding")
+  })
+
+  test("opens the selected route when devices are available", () => {
+    expect(resolveAppSurface("app", "ready", 1)).toBe("route")
+  })
+})

--- a/ui/tui/src/app/surface.ts
+++ b/ui/tui/src/app/surface.ts
@@ -1,0 +1,13 @@
+export type AppMode = "home" | "app"
+
+export type AppSurface = "home" | "onboarding" | "route"
+
+export function resolveAppSurface(appMode: AppMode, devicesStatus: string, deviceCount: number): AppSurface {
+  if (appMode === "home") {
+    return "home"
+  }
+  if (devicesStatus !== "ready" || deviceCount === 0) {
+    return "onboarding"
+  }
+  return "route"
+}


### PR DESCRIPTION
## Summary
- always render the animated Yokai destination screen at startup
- keep onboarding for route activation when no devices are configured
- allow `G` to return home from onboarding
- cover startup surface selection with Bun tests

## Validation
- `make build`
- `make lint`
- `make tui-test tui-build tui-compile`
- runtime-verified the compiled macOS arm64 TUI against an empty-device daemon: home -> Enter -> onboarding -> G -> home

## Local baseline note
`make check` reaches pre-existing macOS-only failures in `internal/agent`: the container endpoint expects Docker to be available, and `TestSystemInfoHelpers/getTotalRAM` type-asserts `int64` while macOS returns `int`. The affected TUI checks and all builds pass.