### PR TITLE
chore: add repository code ownership [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Spencer is the sole approving owner for protected promotion branches.
+* @spencerbull
+/.github/ @spencerbull


### PR DESCRIPTION
Bootstrap explicit code ownership before enabling the long-lived branch ruleset. All files and the workflow directory require approval from @spencerbull.