### PR TITLE
fix: run deployment rules tests with setup Node

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -61,7 +61,11 @@ jobs:
           chmod 0755 "${RUNNER_TEMP}/firebase"
           echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
       - name: Test Firestore security rules
-        run: npm test
+        shell: bash
+        run: |
+          node_binary="$(command -v node)"
+          firebase emulators:exec --only firestore --project demo-yokai --config ../../firebase.json \
+            "\"${node_binary}\" --test --test-concurrency=1 firestore.rules.test.mjs"
         working-directory: tests/firebase
 
   deploy-rules:


### PR DESCRIPTION
## Summary

- invoke the Actions setup-node executable by absolute path during `firebase emulators:exec`
- avoid the standalone Firebase CLI intercepting `node --test` as its packaged runtime

## Evidence

- failed development deployment: https://github.com/spencerbull/Yokai/actions/runs/29292521509
- exact Bash argument expansion and workflow YAML validated locally
- independent review approved the one-file fix

## Rollout

After this reaches `develop`, the branch-bound development deployment will rerun. Promotion to `staging` remains gated on that success.