### PR TITLE
Harden Firestore cloud backups and reconcile main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,63 @@ jobs:
           windows_contents=$(unzip -Z1 "$windows_archive")
           grep -qx 'yokai.exe' <<< "$windows_contents"
           grep -qx 'yokai-tui.exe' <<< "$windows_contents"
+
+  # This context is required on every long-lived branch. The Firestore suite
+  # currently lives on the cloud-sync branches, so keep the context available
+  # on main while still failing if a branch contains only a partial suite.
+  firestore-rules:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect Firestore rules suite
+        id: firestore-suite
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_files=(
+            firebase.json
+            firestore.rules
+            tests/firebase/package.json
+            tests/firebase/package-lock.json
+          )
+          present=0
+          for file in "${required_files[@]}"; do
+            if [[ -f "$file" ]]; then
+              present=$((present + 1))
+            fi
+          done
+
+          if [[ "$present" -eq 0 ]]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$present" -eq "${#required_files[@]}" ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Firestore rules test suite is incomplete ($present/${#required_files[@]} files present)"
+            exit 1
+          fi
+      - uses: actions/setup-node@v4
+        if: steps.firestore-suite.outputs.present == 'true'
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tests/firebase/package-lock.json
+      - uses: actions/setup-java@v4
+        if: steps.firestore-suite.outputs.present == 'true'
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install Firebase test dependencies
+        if: steps.firestore-suite.outputs.present == 'true'
+        run: npm ci
+        working-directory: tests/firebase
+      - name: Install Firebase CLI
+        if: steps.firestore-suite.outputs.present == 'true'
+        run: npm install --global firebase-tools@15.22.4
+      - name: Test Firestore security rules
+        if: steps.firestore-suite.outputs.present == 'true'
+        run: npm test
+        working-directory: tests/firebase
+      - name: Record unavailable suite
+        if: steps.firestore-suite.outputs.present != 'true'
+        run: echo "Firestore rules suite is not present on this branch"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ yokai solves all of this with a single binary. Install it, point it at your mach
 
 ### Fleet Management
 - **Onboarding wizard** -- connect devices via LAN scan, Tailscale peer discovery, or manual IP entry
+- **GPU-aware Tailscale discovery** -- surface peer tags and highlight dedicated compute nodes carrying Yokai's recommended `tag:ai-gpu` identity
 - **SSH bootstrap** -- pre-flight checks (Docker, GPU, disk space), agent deployment, and systemd service installation in one step
 - **Device manager** -- add, edit, remove, and test connectivity for all devices from the TUI
 - **Secure by default** -- auto-generated bearer tokens for agent authentication, SSH key resolution with agent/key/password fallback
@@ -134,6 +135,19 @@ yokai
 # 5. Set up your HuggingFace token (optional, for gated models)
 # 6. Tab over to "Deploy" and pick a Best-Known-Config to run your first model
 ```
+
+### Tag GPU compute nodes in Tailscale
+
+Yokai can import online peers from `tailscale status --json`. Dedicated GPU servers tagged with `tag:ai-gpu` receive an **AI GPU** badge and are easier to identify in the device picker. The tag is recommended, not required.
+
+Define `tag:ai-gpu` and its owner in your tailnet policy, then apply it from **Tailscale Admin Console -> Machines -> device -> Edit tags** or authenticate the dedicated server with the tag:
+
+```bash
+sudo tailscale login --advertise-tags=tag:ai-gpu
+sudo tailscale up --advertise-tags=tag:ai-gpu --force-reauth
+```
+
+Only tag dedicated, non-human server nodes: Tailscale tags replace user-based device identity and do not grant network or SSH access. See the [full Tailscale GPU-node guide](https://spencerbull.github.io/yokai-docs/guides/tailscale-gpu-nodes/) for `tagOwners`, access-policy examples, Yokai verification, and troubleshooting.
 
 ### Running the Daemon
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,37 +4,38 @@
 
 ### Goal and done criteria
 
-- [ ] Reconcile current `main` into the cloud-sync staging line without losing the Tailscale documentation or production workflow safeguards.
-- [ ] Make Firestore envelope validation match the Go encryption format exactly.
-- [ ] Cover valid create/read/update/delete plus malformed, unauthorized, query/list, type, length, encoding, and size rejection paths in the emulator.
+- [x] Reconcile current `main` into the cloud-sync development line without losing the Tailscale documentation or production workflow safeguards.
+- [x] Make Firestore envelope validation match the Go encryption format exactly.
+- [x] Cover valid create/read/update/delete plus malformed, unauthorized, query/list, type, length, encoding, and size rejection paths in the emulator.
 - [ ] Pass focused cloud/rules tests, full repository checks, workflow/static validation, and independent security review.
-- [ ] Push `sbull-agent/firestore-hardening` and open a reviewable PR targeting `staging`; do not merge or approve the production deployment in this loop.
+- [ ] Push `sbull-agent/firestore-hardening` and open a reviewable PR targeting `develop`; do not merge or promote it in this loop.
 
 ### Stream
 
 | Branch | Worktree | Base | Scope |
 |---|---|---|---|
-| `sbull-agent/firestore-hardening` | `/Users/spencerbull/src/github.com/spencerbull/Yokai-firestore-hardening` | `origin/staging` | rules, emulator tests, branch reconciliation, CI/release preservation |
+| `sbull-agent/firestore-hardening` | `/Users/spencerbull/src/github.com/spencerbull/Yokai-firestore-hardening-develop` | `origin/develop` + current `origin/main` | rules, emulator tests, branch reconciliation, CI/release preservation |
 
 ### Allowed and forbidden actions
 
-- Allowed: isolated worktree/branch changes, local emulators, tests, static checks, push, and a PR targeting `staging`.
-- Forbidden without a new explicit approval: merge to `staging` or `main`, approve `firebase-production`, deploy production rules, change secrets/billing/IAM, or touch real user data.
+- Allowed: isolated worktree/branch changes, local emulators, tests, static checks, push, and a PR targeting `develop`.
+- Forbidden without a new explicit approval: merge or promote the PR, approve `firebase-production`, deploy production rules, change secrets/billing/IAM, or touch real user data.
 
 ### Required gates
 
-- [ ] Firestore emulator validity/invalidity suite.
-- [ ] Focused Go race tests and vet for cloud/config/daemon ownership.
-- [ ] Full CI-equivalent build, lint, TUI, and release-package checks.
-- [ ] Action/workflow contract checks and clean diff.
+- [x] Firestore emulator validity/invalidity suite (50/50).
+- [x] Focused Go race tests and vet for cloud/config/daemon ownership.
+- [x] Full CI-equivalent build, lint, TUI, and release-package checks.
+- [x] Action/workflow contract checks and clean diff.
 - [ ] Independent security and branch-reconciliation reviews resolved.
 - [ ] GitHub PR checks green.
 
 ### Current status
 
-- [x] Persistent isolated worktree created from current `origin/staging` (`90e148cf`).
-- [ ] Merge current `origin/main` (`0f170d69`) and resolve shared files intentionally.
-- [ ] Implement and validate the hardening diff.
+- [x] Persistent isolated worktree created from current `origin/develop` (`162b476`).
+- [x] Merge current `origin/main` (`0f170d69`) and resolve the CI workflow intentionally.
+- [x] Implement and locally validate the hardening diff.
+- [x] Preserve the superseded staging-based work as `sbull-agent/firestore-hardening-staging-scratch` until the development PR lands.
 
 ### Open checkpoints
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [x] Reconcile current `main` into the cloud-sync development line without losing the Tailscale documentation or production workflow safeguards.
 - [x] Make Firestore envelope validation match the Go encryption format exactly.
 - [x] Cover valid create/read/update/delete plus malformed, unauthorized, query/list, type, length, encoding, and size rejection paths in the emulator.
-- [ ] Pass focused cloud/rules tests, full repository checks, workflow/static validation, and independent security review.
+- [x] Pass focused cloud/rules tests, full repository checks, workflow/static validation, and independent security review.
 - [ ] Push `sbull-agent/firestore-hardening` and open a reviewable PR targeting `develop`; do not merge or promote it in this loop.
 
 ### Stream
@@ -23,11 +23,11 @@
 
 ### Required gates
 
-- [x] Firestore emulator validity/invalidity suite (50/50).
+- [x] Firestore emulator validity/invalidity suite (55/55).
 - [x] Focused Go race tests and vet for cloud/config/daemon ownership.
 - [x] Full CI-equivalent build, lint, TUI, and release-package checks.
 - [x] Action/workflow contract checks and clean diff.
-- [ ] Independent security and branch-reconciliation reviews resolved.
+- [x] Independent security and branch-reconciliation reviews resolved.
 - [ ] GitHub PR checks green.
 
 ### Current status
@@ -36,6 +36,7 @@
 - [x] Merge current `origin/main` (`0f170d69`) and resolve the CI workflow intentionally.
 - [x] Implement and locally validate the hardening diff.
 - [x] Preserve the superseded staging-based work as `sbull-agent/firestore-hardening-staging-scratch` until the development PR lands.
+- [x] Resolve final-review findings for canonical Base64, method-specific conflict errors, and missing Firestore update times.
 
 ### Open checkpoints
 
@@ -45,7 +46,7 @@
 ## Goal and done criteria
 
 - [x] Create long-lived `develop`, `staging`, and `main` branches.
-- [x] Make `develop` the default branch and retarget feature PR #79.
+- [x] Retarget feature PR #79 to `develop`; `main` remains the public default branch.
 - [x] Require PRs, passing CI, resolved threads, and `@spencerbull` code-owner approval on all long-lived branches.
 - [x] Block direct pushes, force pushes, and deletion; keep CI/thread gates non-bypassable and allow Spencer to bypass only the self-approval rule while merging a PR.
 - [x] Map branches to `firebase-development`, `firebase-staging`, and `firebase-production` GitHub Environments.

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,46 @@
 # Three-environment Firebase rollout
 
+## Firestore validation hardening (2026-07-20)
+
+### Goal and done criteria
+
+- [ ] Reconcile current `main` into the cloud-sync staging line without losing the Tailscale documentation or production workflow safeguards.
+- [ ] Make Firestore envelope validation match the Go encryption format exactly.
+- [ ] Cover valid create/read/update/delete plus malformed, unauthorized, query/list, type, length, encoding, and size rejection paths in the emulator.
+- [ ] Pass focused cloud/rules tests, full repository checks, workflow/static validation, and independent security review.
+- [ ] Push `sbull-agent/firestore-hardening` and open a reviewable PR targeting `staging`; do not merge or approve the production deployment in this loop.
+
+### Stream
+
+| Branch | Worktree | Base | Scope |
+|---|---|---|---|
+| `sbull-agent/firestore-hardening` | `/Users/spencerbull/src/github.com/spencerbull/Yokai-firestore-hardening` | `origin/staging` | rules, emulator tests, branch reconciliation, CI/release preservation |
+
+### Allowed and forbidden actions
+
+- Allowed: isolated worktree/branch changes, local emulators, tests, static checks, push, and a PR targeting `staging`.
+- Forbidden without a new explicit approval: merge to `staging` or `main`, approve `firebase-production`, deploy production rules, change secrets/billing/IAM, or touch real user data.
+
+### Required gates
+
+- [ ] Firestore emulator validity/invalidity suite.
+- [ ] Focused Go race tests and vet for cloud/config/daemon ownership.
+- [ ] Full CI-equivalent build, lint, TUI, and release-package checks.
+- [ ] Action/workflow contract checks and clean diff.
+- [ ] Independent security and branch-reconciliation reviews resolved.
+- [ ] GitHub PR checks green.
+
+### Current status
+
+- [x] Persistent isolated worktree created from current `origin/staging` (`90e148cf`).
+- [ ] Merge current `origin/main` (`0f170d69`) and resolve shared files intentionally.
+- [ ] Implement and validate the hardening diff.
+
+### Open checkpoints
+
+- Production remains a human gate even after staging validation passes.
+- The production environment variable names and branch policy exist; values are not considered proven until the gated production workflows validate them.
+
 ## Goal and done criteria
 
 - [x] Create long-lived `develop`, `staging`, and `main` branches.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - [x] Make Firestore envelope validation match the Go encryption format exactly.
 - [x] Cover valid create/read/update/delete plus malformed, unauthorized, query/list, type, length, encoding, and size rejection paths in the emulator.
 - [x] Pass focused cloud/rules tests, full repository checks, workflow/static validation, and independent security review.
-- [ ] Push `sbull-agent/firestore-hardening` and open a reviewable PR targeting `develop`; do not merge or promote it in this loop.
+- [x] Push `sbull-agent/firestore-hardening` and open draft PR #88 targeting `develop`; do not merge or promote it in this loop.
 
 ### Stream
 
@@ -28,7 +28,7 @@
 - [x] Full CI-equivalent build, lint, TUI, and release-package checks.
 - [x] Action/workflow contract checks and clean diff.
 - [x] Independent security and branch-reconciliation reviews resolved.
-- [ ] GitHub PR checks green.
+- [x] GitHub push and PR checks green (runs `29801252009` and `29801264647`).
 
 ### Current status
 

--- a/docs/cloud-device-config.md
+++ b/docs/cloud-device-config.md
@@ -26,6 +26,11 @@ passphrase, and Firebase stores only ciphertext. Later saves require the current
 passphrase before replacing the existing backup. Yokai refuses to upload an
 empty device list unless `--allow-empty` is explicitly supplied.
 
+Every save is conditional on the version Yokai just read. If another computer
+creates or replaces the backup first, the save stops instead of overwriting the
+newer copy. Run `yokai cloud save` again to review and replace that latest
+backup deliberately.
+
 To inspect and restore a backup:
 
 ```bash
@@ -77,6 +82,13 @@ The Google account controls which Firestore document Firebase can access. A
 separate encryption passphrase never leaves the machine and prevents Firebase,
 project operators, or a database export from reading device hosts, SSH details,
 or agent tokens. Losing the passphrase makes the cloud copy unrecoverable.
+
+Firestore rules permit only a single-document read for the signed-in owner's
+UID; collection queries and subcollections are denied. Creates and updates must
+contain exactly the encrypted-envelope fields and satisfy the supported
+algorithm, version, encoding, and size limits. The client validates the same
+contract before upload and after download. Owners may still delete an older
+malformed document so a bad legacy backup cannot become undeletable.
 
 Firebase refresh credentials are stored locally at
 `~/.config/yokai/cloud-auth.json` with mode `0600`. The initial Google grant only

--- a/firebase.json
+++ b/firebase.json
@@ -4,7 +4,7 @@
   },
   "emulators": {
     "firestore": {
-      "port": 8080
+      "port": 8088
     },
     "singleProjectMode": true
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,22 +7,33 @@ service cloud.firestore {
         return request.auth != null && request.auth.uid == userId;
       }
 
+      function isRawBase64(value) {
+        return value is string && value.matches('[A-Za-z0-9+/]+');
+      }
+
       function isEncryptedEnvelope() {
-        return request.resource.data.keys().hasOnly([
+        return request.resource.data.keys().hasAll([
           'version', 'cipher', 'kdf', 'salt', 'nonce', 'ciphertext'
         ])
+        && request.resource.data.keys().hasOnly([
+          'version', 'cipher', 'kdf', 'salt', 'nonce', 'ciphertext'
+        ])
+        && request.resource.data.version is int
         && request.resource.data.version == 1
         && request.resource.data.cipher == 'aes-256-gcm'
         && request.resource.data.kdf == 'argon2id-3-65536-4'
-        && request.resource.data.salt is string
-        && request.resource.data.salt.size() <= 32
-        && request.resource.data.nonce is string
-        && request.resource.data.nonce.size() <= 24
-        && request.resource.data.ciphertext is string
-        && request.resource.data.ciphertext.size() <= 900000;
+        && isRawBase64(request.resource.data.salt)
+        && request.resource.data.salt.size() == 22
+        && isRawBase64(request.resource.data.nonce)
+        && request.resource.data.nonce.size() == 16
+        && isRawBase64(request.resource.data.ciphertext)
+        && request.resource.data.ciphertext.size() >= 56
+        && request.resource.data.ciphertext.size() <= 900000
+        && request.resource.data.ciphertext.size() % 4 != 1;
       }
 
-      allow read, delete: if isOwner();
+      allow get, delete: if isOwner();
+      allow list: if false;
       allow create, update: if isOwner() && isEncryptedEnvelope();
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,6 +11,16 @@ service cloud.firestore {
         return value is string && value.matches('[A-Za-z0-9+/]+');
       }
 
+      function isCanonicalRawBase64(value) {
+        return isRawBase64(value)
+          && value.size() % 4 != 1
+          && (
+            value.size() % 4 == 0
+            || (value.size() % 4 == 2 && value.matches('[A-Za-z0-9+/]*[AQgw]'))
+            || (value.size() % 4 == 3 && value.matches('[A-Za-z0-9+/]*[AEIMQUYcgkosw048]'))
+          );
+      }
+
       function isEncryptedEnvelope() {
         return request.resource.data.keys().hasAll([
           'version', 'cipher', 'kdf', 'salt', 'nonce', 'ciphertext'
@@ -22,14 +32,13 @@ service cloud.firestore {
         && request.resource.data.version == 1
         && request.resource.data.cipher == 'aes-256-gcm'
         && request.resource.data.kdf == 'argon2id-3-65536-4'
-        && isRawBase64(request.resource.data.salt)
+        && isCanonicalRawBase64(request.resource.data.salt)
         && request.resource.data.salt.size() == 22
-        && isRawBase64(request.resource.data.nonce)
+        && isCanonicalRawBase64(request.resource.data.nonce)
         && request.resource.data.nonce.size() == 16
-        && isRawBase64(request.resource.data.ciphertext)
+        && isCanonicalRawBase64(request.resource.data.ciphertext)
         && request.resource.data.ciphertext.size() >= 56
-        && request.resource.data.ciphertext.size() <= 900000
-        && request.resource.data.ciphertext.size() % 4 != 1;
+        && request.resource.data.ciphertext.size() <= 900000;
       }
 
       allow get, delete: if isOwner();

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -733,7 +733,7 @@ func getTotalRAM() map[string]interface{} {
 	data, err := os.ReadFile("/proc/meminfo")
 	if err != nil {
 		return map[string]interface{}{
-			"total_mb": 0,
+			"total_mb": int64(0),
 			"error":    err.Error(),
 		}
 	}
@@ -749,7 +749,7 @@ func getTotalRAM() map[string]interface{} {
 			}
 		}
 	}
-	return map[string]interface{}{"total_mb": 0}
+	return map[string]interface{}{"total_mb": int64(0)}
 }
 
 func getTotalDisk() map[string]interface{} {
@@ -757,7 +757,7 @@ func getTotalDisk() map[string]interface{} {
 	out, err := cmd.Output()
 	if err != nil {
 		return map[string]interface{}{
-			"total_gb": 0,
+			"total_gb": int64(0),
 			"error":    err.Error(),
 		}
 	}
@@ -770,5 +770,5 @@ func getTotalDisk() map[string]interface{} {
 			"total_gb": size,
 		}
 	}
-	return map[string]interface{}{"total_gb": 0}
+	return map[string]interface{}{"total_gb": int64(0)}
 }

--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -71,7 +71,7 @@ Only device records are synced. Other Yokai settings stay local.
 }
 
 type cloudConfigClient interface {
-	Put(context.Context, cloudsync.Envelope) (cloudsync.Metadata, error)
+	Put(context.Context, cloudsync.Envelope, *cloudsync.Metadata) (cloudsync.Metadata, error)
 	Get(context.Context) (cloudsync.Envelope, cloudsync.Metadata, error)
 	Delete(context.Context) error
 }
@@ -225,7 +225,11 @@ func saveCloudConfig(ctx context.Context, client cloudConfigClient, credentials 
 	if err != nil {
 		return err
 	}
-	metadata, err := client.Put(ctx, envelope)
+	var previous *cloudsync.Metadata
+	if hasExisting {
+		previous = &existingMetadata
+	}
+	metadata, err := client.Put(ctx, envelope, previous)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cloud_test.go
+++ b/internal/cli/cloud_test.go
@@ -95,15 +95,21 @@ type fakeCloudConfigClient struct {
 	getErr      error
 	putCalls    int
 	putEnvelope cloudsync.Envelope
+	putPrevious *cloudsync.Metadata
+	putErr      error
 }
 
 func (f *fakeCloudConfigClient) Get(context.Context) (cloudsync.Envelope, cloudsync.Metadata, error) {
 	return f.getEnvelope, f.getMetadata, f.getErr
 }
 
-func (f *fakeCloudConfigClient) Put(_ context.Context, envelope cloudsync.Envelope) (cloudsync.Metadata, error) {
+func (f *fakeCloudConfigClient) Put(_ context.Context, envelope cloudsync.Envelope, previous *cloudsync.Metadata) (cloudsync.Metadata, error) {
 	f.putCalls++
 	f.putEnvelope = envelope
+	f.putPrevious = previous
+	if f.putErr != nil {
+		return cloudsync.Metadata{}, f.putErr
+	}
 	return cloudsync.Metadata{UpdatedAt: time.Date(2026, 7, 13, 21, 0, 0, 0, time.UTC)}, nil
 }
 
@@ -170,15 +176,16 @@ func TestSaveCloudConfigConfirmedAndAllowEmptyPaths(t *testing.T) {
 
 	t.Run("confirmed replacement", func(t *testing.T) {
 		existing := testCloudEnvelope(t, []config.Device{{ID: "cloud-device"}}, passphrase)
-		client := &fakeCloudConfigClient{getEnvelope: existing}
+		existingMetadata := cloudsync.Metadata{UpdatedAt: time.Date(2026, 7, 13, 20, 0, 0, 0, time.UTC)}
+		client := &fakeCloudConfigClient{getEnvelope: existing, getMetadata: existingMetadata}
 		cfg := config.DefaultConfig()
 		cfg.Devices = []config.Device{{ID: "local-device"}}
 		var outputs []interface{}
 		if err := saveCloudConfig(context.Background(), client, credentials, cfg, true, testCloudInteraction("", false, passphrase, &outputs)); err != nil {
 			t.Fatal(err)
 		}
-		if client.putCalls != 1 || len(outputs) != 1 {
-			t.Fatalf("replacement putCalls=%d outputs=%#v", client.putCalls, outputs)
+		if client.putCalls != 1 || client.putPrevious == nil || !client.putPrevious.UpdatedAt.Equal(existingMetadata.UpdatedAt) || len(outputs) != 1 {
+			t.Fatalf("replacement putCalls=%d previous=%#v outputs=%#v", client.putCalls, client.putPrevious, outputs)
 		}
 	})
 
@@ -198,7 +205,32 @@ func TestSaveCloudConfigConfirmedAndAllowEmptyPaths(t *testing.T) {
 		if client.putCalls != 1 {
 			t.Fatalf("empty backup putCalls=%d", client.putCalls)
 		}
+		if client.putPrevious != nil {
+			t.Fatalf("new backup previous = %#v", client.putPrevious)
+		}
 	})
+}
+
+func TestSaveCloudConfigDoesNotReportSuccessAfterConcurrentChange(t *testing.T) {
+	const passphrase = "correct test passphrase"
+	existingMetadata := cloudsync.Metadata{UpdatedAt: time.Date(2026, 7, 13, 20, 0, 0, 0, time.UTC)}
+	client := &fakeCloudConfigClient{
+		getEnvelope: testCloudEnvelope(t, []config.Device{{ID: "cloud-device"}}, passphrase),
+		getMetadata: existingMetadata,
+		putErr:      cloudsync.ErrCloudConfigChanged,
+	}
+	credentials := &cloudsync.Credentials{Email: "user@example.com"}
+	cfg := config.DefaultConfig()
+	cfg.Devices = []config.Device{{ID: "local-device"}}
+	var outputs []interface{}
+
+	err := saveCloudConfig(context.Background(), client, credentials, cfg, true, testCloudInteraction("", false, passphrase, &outputs))
+	if !errors.Is(err, cloudsync.ErrCloudConfigChanged) {
+		t.Fatalf("saveCloudConfig() error = %v", err)
+	}
+	if client.putCalls != 1 || len(outputs) != 0 {
+		t.Fatalf("conflict putCalls=%d outputs=%#v", client.putCalls, outputs)
+	}
 }
 
 func TestLoadCloudConfigDoesNotMutateOnCancelOrWrongPassphrase(t *testing.T) {

--- a/internal/cloudsync/client.go
+++ b/internal/cloudsync/client.go
@@ -93,6 +93,9 @@ func (c *Client) Put(ctx context.Context, envelope Envelope, previous *Metadata)
 	if err := c.do(ctx, http.MethodPatch, target.String(), document, &response); err != nil {
 		return Metadata{}, err
 	}
+	if response.UpdateTime.IsZero() {
+		return Metadata{}, fmt.Errorf("firestore save response is missing its update time")
+	}
 	return Metadata{UpdatedAt: response.UpdateTime, Size: len(envelope.Ciphertext)}, nil
 }
 
@@ -101,6 +104,9 @@ func (c *Client) Get(ctx context.Context) (Envelope, Metadata, error) {
 	var document firestoreDocument
 	if err := c.do(ctx, http.MethodGet, c.documentURL, nil, &document); err != nil {
 		return Envelope{}, Metadata{}, err
+	}
+	if document.UpdateTime.IsZero() {
+		return Envelope{}, Metadata{}, fmt.Errorf("firestore backup response is missing its update time")
 	}
 	envelope, err := fieldsToEnvelope(document.Fields)
 	if err != nil {
@@ -153,9 +159,14 @@ func (c *Client) do(ctx context.Context, method, requestURL string, requestBody,
 		}
 		_ = json.Unmarshal(data, &apiError)
 		message := apiError.Error.Message
-		switch apiError.Error.Status {
-		case "FAILED_PRECONDITION", "ABORTED", "ALREADY_EXISTS":
+		if method == http.MethodPatch && (resp.StatusCode == http.StatusConflict || resp.StatusCode == http.StatusPreconditionFailed) {
 			return ErrCloudConfigChanged
+		}
+		if method == http.MethodPatch {
+			switch apiError.Error.Status {
+			case "FAILED_PRECONDITION", "ABORTED", "ALREADY_EXISTS":
+				return ErrCloudConfigChanged
+			}
 		}
 		if resp.StatusCode == http.StatusNotFound && isMissingFirestoreDocument(message) {
 			return fmt.Errorf("%w; run 'yokai cloud save' first", ErrNoCloudConfig)

--- a/internal/cloudsync/client.go
+++ b/internal/cloudsync/client.go
@@ -19,6 +19,14 @@ const maxResponseSize = 2 << 20
 // ErrNoCloudConfig indicates that the signed-in user has not saved a cloud copy.
 var ErrNoCloudConfig = errors.New("no cloud device backup found")
 
+// ErrCloudConfigChanged indicates that a conditional save lost a race with
+// another writer and must be retried from a fresh read.
+var ErrCloudConfigChanged = errors.New("cloud device backup changed; rerun 'yokai cloud save' to review the latest backup")
+
+// ErrCloudResponseTooLarge indicates that Firestore returned more data than a
+// Yokai cloud-config response is allowed to contain.
+var ErrCloudResponseTooLarge = errors.New("cloud device backup response is too large")
+
 // Client calls Firestore's REST API using a Firebase user ID token.
 type Client struct {
 	documentURL string
@@ -58,11 +66,31 @@ func NewClient(ctx context.Context) (*Client, *Credentials, error) {
 	return &Client{documentURL: documentURL, idToken: idToken, http: httpClient}, credentials, nil
 }
 
-// Put uploads one encrypted device configuration envelope.
-func (c *Client) Put(ctx context.Context, envelope Envelope) (Metadata, error) {
+// Put uploads one encrypted device configuration envelope. A nil previous
+// value requires that no backup exists; a non-nil value requires the exact
+// update time observed by Get so concurrent saves cannot silently overwrite.
+func (c *Client) Put(ctx context.Context, envelope Envelope, previous *Metadata) (Metadata, error) {
+	if err := validateEnvelope(envelope); err != nil {
+		return Metadata{}, fmt.Errorf("refusing invalid cloud device config: %w", err)
+	}
+	target, err := url.Parse(c.documentURL)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("parsing Firestore document URL: %w", err)
+	}
+	query := target.Query()
+	if previous == nil {
+		query.Set("currentDocument.exists", "false")
+	} else {
+		if previous.UpdatedAt.IsZero() {
+			return Metadata{}, fmt.Errorf("cloud device backup update time is missing")
+		}
+		query.Set("currentDocument.updateTime", previous.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	}
+	target.RawQuery = query.Encode()
+
 	document := firestoreDocument{Fields: envelopeToFields(envelope)}
 	var response firestoreDocument
-	if err := c.do(ctx, http.MethodPatch, document, &response); err != nil {
+	if err := c.do(ctx, http.MethodPatch, target.String(), document, &response); err != nil {
 		return Metadata{}, err
 	}
 	return Metadata{UpdatedAt: response.UpdateTime, Size: len(envelope.Ciphertext)}, nil
@@ -71,7 +99,7 @@ func (c *Client) Put(ctx context.Context, envelope Envelope) (Metadata, error) {
 // Get downloads the current encrypted device configuration envelope.
 func (c *Client) Get(ctx context.Context) (Envelope, Metadata, error) {
 	var document firestoreDocument
-	if err := c.do(ctx, http.MethodGet, nil, &document); err != nil {
+	if err := c.do(ctx, http.MethodGet, c.documentURL, nil, &document); err != nil {
 		return Envelope{}, Metadata{}, err
 	}
 	envelope, err := fieldsToEnvelope(document.Fields)
@@ -83,10 +111,10 @@ func (c *Client) Get(ctx context.Context) (Envelope, Metadata, error) {
 
 // Delete permanently removes the user's cloud snapshot.
 func (c *Client) Delete(ctx context.Context) error {
-	return c.do(ctx, http.MethodDelete, nil, nil)
+	return c.do(ctx, http.MethodDelete, c.documentURL, nil, nil)
 }
 
-func (c *Client) do(ctx context.Context, method string, requestBody, responseBody interface{}) error {
+func (c *Client) do(ctx context.Context, method, requestURL string, requestBody, responseBody interface{}) error {
 	var body io.Reader
 	if requestBody != nil {
 		data, err := json.Marshal(requestBody)
@@ -95,7 +123,7 @@ func (c *Client) do(ctx context.Context, method string, requestBody, responseBod
 		}
 		body = bytes.NewReader(data)
 	}
-	req, err := http.NewRequestWithContext(ctx, method, c.documentURL, body)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
 	if err != nil {
 		return fmt.Errorf("creating Firestore request: %w", err)
 	}
@@ -109,18 +137,26 @@ func (c *Client) do(ctx context.Context, method string, requestBody, responseBod
 		return fmt.Errorf("calling Firestore: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 	if err != nil {
 		return fmt.Errorf("reading Firestore response: %w", err)
+	}
+	if len(data) > maxResponseSize {
+		return ErrCloudResponseTooLarge
 	}
 	if resp.StatusCode >= 400 {
 		var apiError struct {
 			Error struct {
 				Message string `json:"message"`
+				Status  string `json:"status"`
 			} `json:"error"`
 		}
 		_ = json.Unmarshal(data, &apiError)
 		message := apiError.Error.Message
+		switch apiError.Error.Status {
+		case "FAILED_PRECONDITION", "ABORTED", "ALREADY_EXISTS":
+			return ErrCloudConfigChanged
+		}
 		if resp.StatusCode == http.StatusNotFound && isMissingFirestoreDocument(message) {
 			return fmt.Errorf("%w; run 'yokai cloud save' first", ErrNoCloudConfig)
 		}
@@ -157,6 +193,9 @@ func envelopeToFields(envelope Envelope) map[string]firestoreValue {
 }
 
 func fieldsToEnvelope(fields map[string]firestoreValue) (Envelope, error) {
+	if len(fields) != 6 {
+		return Envelope{}, fmt.Errorf("cloud device config has an invalid field set")
+	}
 	version, err := strconv.Atoi(fields["version"].IntegerValue)
 	if err != nil {
 		return Envelope{}, fmt.Errorf("cloud device config has an invalid version")
@@ -169,8 +208,8 @@ func fieldsToEnvelope(fields map[string]firestoreValue) (Envelope, error) {
 		Nonce:      fields["nonce"].StringValue,
 		Ciphertext: fields["ciphertext"].StringValue,
 	}
-	if envelope.Cipher == "" || envelope.KDF == "" || envelope.Ciphertext == "" {
-		return Envelope{}, fmt.Errorf("cloud device config is incomplete")
+	if err := validateEnvelope(envelope); err != nil {
+		return Envelope{}, fmt.Errorf("cloud device config is invalid: %w", err)
 	}
 	return envelope, nil
 }

--- a/internal/cloudsync/client_test.go
+++ b/internal/cloudsync/client_test.go
@@ -7,20 +7,39 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/spencerbull/yokai/internal/config"
 )
+
+func clientTestEnvelope(t *testing.T, deviceID string) Envelope {
+	t.Helper()
+	envelope, err := Encrypt(Snapshot{
+		Version: SnapshotVersion,
+		Devices: []config.Device{{ID: deviceID}},
+	}, testPassphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return envelope
+}
 
 func TestClientPutGetDelete(t *testing.T) {
 	t.Parallel()
-	want := Envelope{Version: 1, Cipher: "aes-256-gcm", KDF: "argon2id-3-65536-4", Salt: "salt", Nonce: "nonce", Ciphertext: "ciphertext"}
-	updatedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	want := clientTestEnvelope(t, "device-a")
+	updatedAt := time.Date(2026, 7, 9, 12, 0, 0, 123000000, time.UTC)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer firebase-id-token" {
 			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
 		}
 		switch r.Method {
 		case http.MethodPatch:
+			if got := r.URL.Query().Get("currentDocument.exists"); got != "false" {
+				t.Errorf("currentDocument.exists = %q", got)
+			}
 			var document firestoreDocument
 			if err := json.NewDecoder(r.Body).Decode(&document); err != nil {
 				t.Error(err)
@@ -40,7 +59,7 @@ func TestClientPutGetDelete(t *testing.T) {
 	defer server.Close()
 
 	client := &Client{documentURL: server.URL + "/config", idToken: "firebase-id-token", http: server.Client()}
-	metadata, err := client.Put(context.Background(), want)
+	metadata, err := client.Put(context.Background(), want, nil)
 	if err != nil || !metadata.UpdatedAt.Equal(updatedAt) {
 		t.Fatalf("Put() = %#v, %v", metadata, err)
 	}
@@ -53,19 +72,195 @@ func TestClientPutGetDelete(t *testing.T) {
 	}
 }
 
-func TestFieldsToEnvelopeRejectsIncompleteDocument(t *testing.T) {
+func TestClientConditionalPutPreventsLostUpdatesAndCreateRaces(t *testing.T) {
 	t.Parallel()
-	if _, err := fieldsToEnvelope(map[string]firestoreValue{}); err == nil {
-		t.Fatal("fieldsToEnvelope() accepted an incomplete document")
+	var mu sync.Mutex
+	exists := true
+	stored := clientTestEnvelope(t, "original")
+	updatedAt := time.Date(2026, 7, 9, 12, 0, 0, 123000000, time.UTC)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch r.Method {
+		case http.MethodGet:
+			if !exists {
+				writeFirestoreError(w, http.StatusNotFound, "NOT_FOUND", "Document device_configs/test-user not found.")
+				return
+			}
+			_ = json.NewEncoder(w).Encode(firestoreDocument{Fields: envelopeToFields(stored), UpdateTime: updatedAt})
+		case http.MethodPatch:
+			query := r.URL.Query()
+			if query.Get("currentDocument.exists") == "false" {
+				if exists {
+					writeFirestoreError(w, http.StatusConflict, "ALREADY_EXISTS", "document already exists")
+					return
+				}
+			} else if query.Get("currentDocument.updateTime") != updatedAt.Format(time.RFC3339Nano) || !exists {
+				writeFirestoreError(w, http.StatusBadRequest, "FAILED_PRECONDITION", "document update time changed")
+				return
+			}
+
+			var document firestoreDocument
+			if err := json.NewDecoder(r.Body).Decode(&document); err != nil {
+				t.Error(err)
+				return
+			}
+			next, err := fieldsToEnvelope(document.Fields)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			exists = true
+			stored = next
+			updatedAt = updatedAt.Add(time.Second)
+			_ = json.NewEncoder(w).Encode(firestoreDocument{Fields: document.Fields, UpdateTime: updatedAt})
+		}
+	}))
+	defer server.Close()
+
+	first := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+	second := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+	_, firstMetadata, err := first.Get(context.Background())
+	if err != nil {
+		t.Fatal(err)
 	}
+	_, secondMetadata, err := second.Get(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstReplacement := clientTestEnvelope(t, "first-writer")
+	if _, err := first.Put(context.Background(), firstReplacement, &firstMetadata); err != nil {
+		t.Fatalf("first replacement error = %v", err)
+	}
+	secondReplacement := clientTestEnvelope(t, "stale-writer")
+	if _, err := second.Put(context.Background(), secondReplacement, &secondMetadata); !errors.Is(err, ErrCloudConfigChanged) {
+		t.Fatalf("stale replacement error = %v", err)
+	}
+	got, _, err := first.Get(context.Background())
+	if err != nil || got != firstReplacement {
+		t.Fatalf("stored after stale replacement = %#v, %v", got, err)
+	}
+
+	mu.Lock()
+	exists = false
+	mu.Unlock()
+	firstCreate := clientTestEnvelope(t, "first-create")
+	if _, err := first.Put(context.Background(), firstCreate, nil); err != nil {
+		t.Fatalf("first create error = %v", err)
+	}
+	if _, err := second.Put(context.Background(), clientTestEnvelope(t, "second-create"), nil); !errors.Is(err, ErrCloudConfigChanged) {
+		t.Fatalf("second create error = %v", err)
+	}
+	got, _, err = first.Get(context.Background())
+	if err != nil || got != firstCreate {
+		t.Fatalf("stored after create race = %#v, %v", got, err)
+	}
+}
+
+func writeFirestoreError(w http.ResponseWriter, statusCode int, status, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": map[string]string{"status": status, "message": message},
+	})
+}
+
+func TestClientPutRejectsInvalidEnvelopeBeforeNetwork(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+	client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+
+	invalid := clientTestEnvelope(t, "invalid")
+	invalid.Nonce = "short"
+	if _, err := client.Put(context.Background(), invalid, nil); err == nil {
+		t.Fatal("Put() accepted an invalid envelope")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("invalid Put() sent %d request(s)", requests.Load())
+	}
+	if _, err := client.Put(context.Background(), clientTestEnvelope(t, "missing-time"), &Metadata{}); err == nil {
+		t.Fatal("Put() accepted an empty update time")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("invalid conditional Put() sent %d request(s)", requests.Load())
+	}
+}
+
+func TestFieldsToEnvelopeRejectsInvalidDocuments(t *testing.T) {
+	t.Parallel()
+	valid := envelopeToFields(clientTestEnvelope(t, "valid"))
+	tests := []struct {
+		name   string
+		mutate func(map[string]firestoreValue)
+	}{
+		{name: "missing field", mutate: func(fields map[string]firestoreValue) { delete(fields, "salt") }},
+		{name: "extra field", mutate: func(fields map[string]firestoreValue) {
+			fields["email"] = firestoreValue{StringValue: "leak@example.com"}
+		}},
+		{name: "wrong version type", mutate: func(fields map[string]firestoreValue) { fields["version"] = firestoreValue{StringValue: "1"} }},
+		{name: "wrong string type", mutate: func(fields map[string]firestoreValue) { fields["nonce"] = firestoreValue{IntegerValue: "12"} }},
+		{name: "invalid encoding", mutate: func(fields map[string]firestoreValue) { fields["salt"] = firestoreValue{StringValue: "not-base64!"} }},
+		{name: "oversized ciphertext", mutate: func(fields map[string]firestoreValue) {
+			fields["ciphertext"] = firestoreValue{StringValue: strings.Repeat("A", maxEncodedCiphertextSize+1)}
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fields := make(map[string]firestoreValue, len(valid)+1)
+			for key, value := range valid {
+				fields[key] = value
+			}
+			test.mutate(fields)
+			if _, err := fieldsToEnvelope(fields); err == nil {
+				t.Fatal("fieldsToEnvelope() accepted invalid document")
+			}
+		})
+	}
+}
+
+func TestClientGetResponseSizeBoundary(t *testing.T) {
+	t.Parallel()
+	envelope := clientTestEnvelope(t, "boundary")
+	document, err := json.Marshal(firestoreDocument{Fields: envelopeToFields(envelope), UpdateTime: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("exact limit", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(append(document, []byte(strings.Repeat(" ", maxResponseSize-len(document)))...))
+		}))
+		defer server.Close()
+		client := &Client{documentURL: server.URL, idToken: "token", http: server.Client()}
+		if _, _, err := client.Get(context.Background()); err != nil {
+			t.Fatalf("exact-limit Get() error = %v", err)
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(strings.Repeat("x", maxResponseSize+1)))
+		}))
+		defer server.Close()
+		client := &Client{documentURL: server.URL, idToken: "token", http: server.Client()}
+		if _, _, err := client.Get(context.Background()); !errors.Is(err, ErrCloudResponseTooLarge) {
+			t.Fatalf("over-limit Get() error = %v", err)
+		}
+	})
 }
 
 func TestClientGetMapsMissingBackup(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":{"message":"Document device_configs/test-user not found."}}`))
+		writeFirestoreError(w, http.StatusNotFound, "NOT_FOUND", "Document device_configs/test-user not found.")
 	}))
 	defer server.Close()
 
@@ -79,9 +274,7 @@ func TestClientGetMapsMissingBackup(t *testing.T) {
 func TestClientDoesNotMapBackend404ToMissingBackup(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":{"message":"Project yokai-missing not found."}}`))
+		writeFirestoreError(w, http.StatusNotFound, "NOT_FOUND", "Project yokai-missing not found.")
 	}))
 	defer server.Close()
 

--- a/internal/cloudsync/client_test.go
+++ b/internal/cloudsync/client_test.go
@@ -284,3 +284,61 @@ func TestClientDoesNotMapBackend404ToMissingBackup(t *testing.T) {
 		t.Fatalf("Get() error = %v", err)
 	}
 }
+
+func TestClientConflictMappingIsPatchSpecific(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty precondition response on PATCH", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusPreconditionFailed)
+		}))
+		defer server.Close()
+
+		client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+		if _, err := client.Put(context.Background(), clientTestEnvelope(t, "conflict"), nil); !errors.Is(err, ErrCloudConfigChanged) {
+			t.Fatalf("Put() error = %v", err)
+		}
+	})
+
+	t.Run("structured precondition response on GET", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeFirestoreError(w, http.StatusBadRequest, "FAILED_PRECONDITION", "backend index unavailable")
+		}))
+		defer server.Close()
+
+		client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+		_, _, err := client.Get(context.Background())
+		if err == nil || errors.Is(err, ErrCloudConfigChanged) || !strings.Contains(err.Error(), "backend index unavailable") {
+			t.Fatalf("Get() error = %v", err)
+		}
+	})
+}
+
+func TestClientRejectsSuccessfulResponsesWithoutUpdateTime(t *testing.T) {
+	t.Parallel()
+	envelope := clientTestEnvelope(t, "missing-update-time")
+
+	t.Run("Put", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(firestoreDocument{Fields: envelopeToFields(envelope)})
+		}))
+		defer server.Close()
+
+		client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+		if _, err := client.Put(context.Background(), envelope, nil); err == nil || !strings.Contains(err.Error(), "update time") {
+			t.Fatalf("Put() error = %v", err)
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(firestoreDocument{Fields: envelopeToFields(envelope)})
+		}))
+		defer server.Close()
+
+		client := &Client{documentURL: server.URL + "/config", idToken: "token", http: server.Client()}
+		if _, _, err := client.Get(context.Background()); err == nil || !strings.Contains(err.Error(), "update time") {
+			t.Fatalf("Get() error = %v", err)
+		}
+	})
+}

--- a/internal/cloudsync/crypto.go
+++ b/internal/cloudsync/crypto.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"unicode/utf8"
 
 	"golang.org/x/crypto/argon2"
 
@@ -22,9 +23,16 @@ const (
 	envelopeVersion = 1
 	keySize         = 32
 	saltSize        = 16
+	nonceSize       = 12
+	gcmTagSize      = 16
 	argonTime       = 3
 	argonMemoryKiB  = 64 * 1024
 	argonThreads    = 4
+
+	minPassphraseCharacters  = 12
+	minSnapshotJSONSize      = len(`{"version":1,"devices":[]}`)
+	minCiphertextSize        = minSnapshotJSONSize + gcmTagSize
+	maxEncodedCiphertextSize = 900000
 )
 
 // Snapshot is the portable portion of Yokai configuration. Secrets contained
@@ -47,8 +55,14 @@ type Envelope struct {
 // Encrypt converts a device snapshot to an authenticated AES-256-GCM envelope
 // using an Argon2id key derived from passphrase.
 func Encrypt(snapshot Snapshot, passphrase string) (Envelope, error) {
-	if len(passphrase) < 12 {
+	if utf8.RuneCountInString(passphrase) < minPassphraseCharacters {
 		return Envelope{}, fmt.Errorf("passphrase must contain at least 12 characters")
+	}
+	if snapshot.Version != SnapshotVersion {
+		return Envelope{}, fmt.Errorf("unsupported device config version %d", snapshot.Version)
+	}
+	if snapshot.Devices == nil {
+		snapshot.Devices = []config.Device{}
 	}
 
 	plaintext, err := json.Marshal(snapshot)
@@ -78,32 +92,36 @@ func Encrypt(snapshot Snapshot, passphrase string) (Envelope, error) {
 
 	additionalData := []byte("yokai-device-config-v1")
 	ciphertext := gcm.Seal(nil, nonce, plaintext, additionalData)
-	return Envelope{
+	envelope := Envelope{
 		Version:    envelopeVersion,
 		Cipher:     "aes-256-gcm",
 		KDF:        "argon2id-3-65536-4",
 		Salt:       base64.RawStdEncoding.EncodeToString(salt),
 		Nonce:      base64.RawStdEncoding.EncodeToString(nonce),
 		Ciphertext: base64.RawStdEncoding.EncodeToString(ciphertext),
-	}, nil
+	}
+	if err := validateEnvelope(envelope); err != nil {
+		return Envelope{}, fmt.Errorf("validating encrypted config: %w", err)
+	}
+	return envelope, nil
 }
 
 // Decrypt authenticates and decrypts an envelope into a device snapshot.
 func Decrypt(envelope Envelope, passphrase string) (Snapshot, error) {
-	if envelope.Version != envelopeVersion || envelope.Cipher != "aes-256-gcm" || envelope.KDF != "argon2id-3-65536-4" {
-		return Snapshot{}, fmt.Errorf("unsupported encrypted config format")
+	if err := validateEnvelope(envelope); err != nil {
+		return Snapshot{}, err
 	}
 
-	salt, err := decodeField("salt", envelope.Salt, saltSize)
+	salt, err := decodeCanonicalField("salt", envelope.Salt, saltSize)
 	if err != nil {
 		return Snapshot{}, err
 	}
-	nonce, err := decodeField("nonce", envelope.Nonce, 12)
+	nonce, err := decodeCanonicalField("nonce", envelope.Nonce, nonceSize)
 	if err != nil {
 		return Snapshot{}, err
 	}
 	ciphertext, err := base64.RawStdEncoding.DecodeString(envelope.Ciphertext)
-	if err != nil || len(ciphertext) < 16 {
+	if err != nil {
 		return Snapshot{}, fmt.Errorf("invalid encrypted config ciphertext")
 	}
 
@@ -134,9 +152,29 @@ func Decrypt(envelope Envelope, passphrase string) (Snapshot, error) {
 	return snapshot, nil
 }
 
-func decodeField(name, value string, wantLen int) ([]byte, error) {
+func validateEnvelope(envelope Envelope) error {
+	if envelope.Version != envelopeVersion || envelope.Cipher != "aes-256-gcm" || envelope.KDF != "argon2id-3-65536-4" {
+		return fmt.Errorf("unsupported encrypted config format")
+	}
+	if _, err := decodeCanonicalField("salt", envelope.Salt, saltSize); err != nil {
+		return err
+	}
+	if _, err := decodeCanonicalField("nonce", envelope.Nonce, nonceSize); err != nil {
+		return err
+	}
+	if len(envelope.Ciphertext) > maxEncodedCiphertextSize {
+		return fmt.Errorf("encrypted config ciphertext exceeds %d characters", maxEncodedCiphertextSize)
+	}
+	ciphertext, err := base64.RawStdEncoding.DecodeString(envelope.Ciphertext)
+	if err != nil || len(ciphertext) < minCiphertextSize || base64.RawStdEncoding.EncodeToString(ciphertext) != envelope.Ciphertext {
+		return fmt.Errorf("invalid encrypted config ciphertext")
+	}
+	return nil
+}
+
+func decodeCanonicalField(name, value string, wantLen int) ([]byte, error) {
 	decoded, err := base64.RawStdEncoding.DecodeString(value)
-	if err != nil || len(decoded) != wantLen {
+	if err != nil || len(decoded) != wantLen || base64.RawStdEncoding.EncodeToString(decoded) != value {
 		return nil, fmt.Errorf("invalid encrypted config %s", name)
 	}
 	return decoded, nil

--- a/internal/cloudsync/crypto_test.go
+++ b/internal/cloudsync/crypto_test.go
@@ -1,14 +1,22 @@
 package cloudsync
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"strconv"
+	"strings"
 	"testing"
+
+	"golang.org/x/crypto/argon2"
 
 	"github.com/spencerbull/yokai/internal/config"
 )
 
-func TestEncryptDecryptRoundTrip(t *testing.T) {
-	t.Parallel()
-	snapshot := Snapshot{
+const testPassphrase = "correct horse battery staple"
+
+func testSnapshot() Snapshot {
+	return Snapshot{
 		Version: SnapshotVersion,
 		Devices: []config.Device{{
 			ID:         "finn",
@@ -17,15 +25,28 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 			AgentPort:  7474,
 		}},
 	}
+}
 
-	envelope, err := Encrypt(snapshot, "correct horse battery staple")
+func TestEncryptDecryptRoundTripAndEnvelopeContract(t *testing.T) {
+	t.Parallel()
+	envelope, err := Encrypt(testSnapshot(), testPassphrase)
 	if err != nil {
 		t.Fatalf("Encrypt() error = %v", err)
 	}
-	if envelope.Ciphertext == "" || envelope.Ciphertext == "secret-agent-token" {
-		t.Fatal("Encrypt() did not produce ciphertext")
+	if err := validateEnvelope(envelope); err != nil {
+		t.Fatalf("validateEnvelope() error = %v", err)
 	}
-	decrypted, err := Decrypt(envelope, "correct horse battery staple")
+	if len(envelope.Salt) != 22 || len(envelope.Nonce) != 16 {
+		t.Fatalf("encoded salt/nonce lengths = %d/%d", len(envelope.Salt), len(envelope.Nonce))
+	}
+	if len(envelope.Ciphertext) < 56 || len(envelope.Ciphertext) > maxEncodedCiphertextSize {
+		t.Fatalf("encoded ciphertext length = %d", len(envelope.Ciphertext))
+	}
+	if strings.Contains(envelope.Ciphertext, "secret-agent-token") {
+		t.Fatal("Encrypt() exposed plaintext in ciphertext")
+	}
+
+	decrypted, err := Decrypt(envelope, testPassphrase)
 	if err != nil {
 		t.Fatalf("Decrypt() error = %v", err)
 	}
@@ -34,9 +55,23 @@ func TestEncryptDecryptRoundTrip(t *testing.T) {
 	}
 }
 
-func TestDecryptRejectsWrongPassphraseAndTampering(t *testing.T) {
+func TestEncryptUsesFreshSaltNonceAndCiphertext(t *testing.T) {
 	t.Parallel()
-	envelope, err := Encrypt(Snapshot{Version: SnapshotVersion, Devices: []config.Device{}}, "correct horse battery staple")
+	first, err := Encrypt(testSnapshot(), testPassphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Encrypt(testSnapshot(), testPassphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Salt == second.Salt || first.Nonce == second.Nonce || first.Ciphertext == second.Ciphertext {
+		t.Fatalf("repeated encryption reused random material: first=%#v second=%#v", first, second)
+	}
+}
+
+func TestDecryptRejectsWrongPassphraseAndAuthenticatedFieldTampering(t *testing.T) {
+	envelope, err := Encrypt(testSnapshot(), testPassphrase)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,30 +79,178 @@ func TestDecryptRejectsWrongPassphraseAndTampering(t *testing.T) {
 		t.Fatal("Decrypt() accepted wrong passphrase")
 	}
 
-	envelope.Ciphertext = envelope.Ciphertext[:len(envelope.Ciphertext)-1] + "A"
-	if _, err := Decrypt(envelope, "correct horse battery staple"); err == nil {
-		t.Fatal("Decrypt() accepted modified ciphertext")
+	for _, field := range []string{"salt", "nonce", "ciphertext"} {
+		t.Run(field, func(t *testing.T) {
+			modified := envelope
+			switch field {
+			case "salt":
+				modified.Salt = flipBase64Character(modified.Salt)
+			case "nonce":
+				modified.Nonce = flipBase64Character(modified.Nonce)
+			case "ciphertext":
+				modified.Ciphertext = flipBase64Character(modified.Ciphertext)
+			}
+			if _, err := Decrypt(modified, testPassphrase); err == nil {
+				t.Fatalf("Decrypt() accepted modified %s", field)
+			}
+		})
 	}
 }
 
-func TestDecryptSupportsOriginalSnapshotVersion(t *testing.T) {
-	t.Parallel()
-	envelope, err := Encrypt(Snapshot{Version: 1, Devices: []config.Device{{ID: "original"}}}, "correct horse battery staple")
+func flipBase64Character(value string) string {
+	replacement := byte('A')
+	if value[0] == replacement {
+		replacement = 'B'
+	}
+	return string(replacement) + value[1:]
+}
+
+func TestEnvelopeValidationRejectsEveryMalformedField(t *testing.T) {
+	valid, err := Encrypt(Snapshot{Version: SnapshotVersion, Devices: []config.Device{}}, testPassphrase)
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshot, err := Decrypt(envelope, "correct horse battery staple")
-	if err != nil {
-		t.Fatalf("Decrypt() original snapshot error = %v", err)
+
+	tests := []struct {
+		name   string
+		mutate func(*Envelope)
+	}{
+		{name: "version", mutate: func(value *Envelope) { value.Version = 2 }},
+		{name: "cipher", mutate: func(value *Envelope) { value.Cipher = "plaintext" }},
+		{name: "kdf", mutate: func(value *Envelope) { value.KDF = "argon2id" }},
+		{name: "empty salt", mutate: func(value *Envelope) { value.Salt = "" }},
+		{name: "short salt", mutate: func(value *Envelope) { value.Salt = value.Salt[:21] }},
+		{name: "long salt", mutate: func(value *Envelope) { value.Salt += "A" }},
+		{name: "padded salt", mutate: func(value *Envelope) { value.Salt = value.Salt[:21] + "=" }},
+		{name: "noncanonical salt", mutate: func(value *Envelope) { value.Salt = value.Salt[:21] + "B" }},
+		{name: "empty nonce", mutate: func(value *Envelope) { value.Nonce = "" }},
+		{name: "short nonce", mutate: func(value *Envelope) { value.Nonce = value.Nonce[:15] }},
+		{name: "long nonce", mutate: func(value *Envelope) { value.Nonce += "A" }},
+		{name: "padded nonce", mutate: func(value *Envelope) { value.Nonce = value.Nonce[:15] + "=" }},
+		{name: "empty ciphertext", mutate: func(value *Envelope) { value.Ciphertext = "" }},
+		{name: "short ciphertext", mutate: func(value *Envelope) { value.Ciphertext = strings.Repeat("A", 55) }},
+		{name: "invalid ciphertext length", mutate: func(value *Envelope) { value.Ciphertext = strings.Repeat("A", 57) }},
+		{name: "padded ciphertext", mutate: func(value *Envelope) { value.Ciphertext = strings.Repeat("A", 55) + "=" }},
+		{name: "oversized ciphertext", mutate: func(value *Envelope) { value.Ciphertext = strings.Repeat("A", maxEncodedCiphertextSize+1) }},
 	}
-	if snapshot.Version != 1 || len(snapshot.Devices) != 1 || snapshot.Devices[0].ID != "original" {
-		t.Fatalf("Decrypt() original snapshot = %#v", snapshot)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modified := valid
+			test.mutate(&modified)
+			if err := validateEnvelope(modified); err == nil {
+				t.Fatal("validateEnvelope() accepted malformed envelope")
+			}
+			if _, err := Decrypt(modified, testPassphrase); err == nil {
+				t.Fatal("Decrypt() accepted malformed envelope")
+			}
+		})
 	}
 }
 
-func TestEncryptRequiresStrongPassphrase(t *testing.T) {
+func TestEnvelopeValidationAcceptsCiphertextBoundaries(t *testing.T) {
 	t.Parallel()
-	if _, err := Encrypt(Snapshot{}, "too-short"); err == nil {
-		t.Fatal("Encrypt() accepted a short passphrase")
+	valid, err := Encrypt(Snapshot{Version: SnapshotVersion, Devices: []config.Device{}}, testPassphrase)
+	if err != nil {
+		t.Fatal(err)
 	}
+	for _, size := range []int{base64.RawStdEncoding.EncodedLen(minCiphertextSize), maxEncodedCiphertextSize} {
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			envelope := valid
+			envelope.Ciphertext = strings.Repeat("A", size)
+			if err := validateEnvelope(envelope); err != nil {
+				t.Fatalf("validateEnvelope() rejected ciphertext size %d: %v", size, err)
+			}
+		})
+	}
+}
+
+func TestDecryptRejectsInvalidPlaintextAndSnapshotVersion(t *testing.T) {
+	valid, err := Encrypt(Snapshot{Version: SnapshotVersion, Devices: []config.Device{}}, testPassphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name      string
+		plaintext string
+	}{
+		{name: "invalid JSON", plaintext: "this is deliberately not valid JSON"},
+		{name: "unsupported snapshot", plaintext: `{"version":2,"devices":[]}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			modified := reencryptPlaintext(t, valid, []byte(test.plaintext), testPassphrase)
+			if _, err := Decrypt(modified, testPassphrase); err == nil {
+				t.Fatal("Decrypt() accepted invalid plaintext")
+			}
+		})
+	}
+}
+
+func reencryptPlaintext(t *testing.T, envelope Envelope, plaintext []byte, passphrase string) Envelope {
+	t.Helper()
+	salt, err := base64.RawStdEncoding.DecodeString(envelope.Salt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce, err := base64.RawStdEncoding.DecodeString(envelope.Nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := argon2.IDKey([]byte(passphrase), salt, argonTime, argonMemoryKiB, argonThreads, keySize)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope.Ciphertext = base64.RawStdEncoding.EncodeToString(gcm.Seal(nil, nonce, plaintext, []byte("yokai-device-config-v1")))
+	return envelope
+}
+
+func TestEncryptValidatesSnapshotAndPassphraseCharacters(t *testing.T) {
+	t.Parallel()
+	if _, err := Encrypt(Snapshot{Version: 0}, testPassphrase); err == nil {
+		t.Fatal("Encrypt() accepted an unsupported snapshot version")
+	}
+
+	for _, test := range []struct {
+		name       string
+		passphrase string
+		wantErr    bool
+	}{
+		{name: "11 ASCII characters", passphrase: "12345678901", wantErr: true},
+		{name: "12 ASCII characters", passphrase: "123456789012"},
+		{name: "11 Unicode characters", passphrase: strings.Repeat("🔒", 11), wantErr: true},
+		{name: "12 Unicode characters", passphrase: strings.Repeat("🔒", 12)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			envelope, err := Encrypt(Snapshot{Version: SnapshotVersion}, test.passphrase)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("Encrypt() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if err == nil {
+				snapshot, err := Decrypt(envelope, test.passphrase)
+				if err != nil || snapshot.Devices == nil || len(snapshot.Devices) != 0 {
+					t.Fatalf("empty snapshot round trip = %#v, %v", snapshot, err)
+				}
+			}
+		})
+	}
+}
+
+func FuzzDecryptRejectsArbitraryEnvelopeWithoutPanicking(f *testing.F) {
+	f.Add(1, "aes-256-gcm", "argon2id-3-65536-4", "salt", "nonce", "ciphertext")
+	f.Fuzz(func(t *testing.T, version int, cipherName, kdf, salt, nonce, ciphertext string) {
+		_, _ = Decrypt(Envelope{
+			Version:    version,
+			Cipher:     cipherName,
+			KDF:        kdf,
+			Salt:       salt,
+			Nonce:      nonce,
+			Ciphertext: ciphertext,
+		}, testPassphrase)
+	})
 }

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -201,19 +201,23 @@ func EnrollmentTagHelp() string {
 Define the tag in your tailnet policy:
   {
     "tagOwners": {
-      "tag:ai-gpu": ["group:infra"]
+      "tag:ai-gpu": ["you@example.com"]
     }
   }
+  Replace you@example.com with the tag owner's tailnet identity.
 
 Apply it to the server:
   Admin console: Machines -> device -> Edit tags -> tag:ai-gpu
-  CLI: sudo tailscale set --advertise-tags=tag:ai-gpu
+  CLI: sudo tailscale login --advertise-tags=tag:ai-gpu
 
-If the device was authenticated as a user, you may need:
+For an already authenticated server that needs reauthentication:
   sudo tailscale up --advertise-tags=tag:ai-gpu --force-reauth
 
-Use tags for non-human server nodes. In Tailscale, tags become the
-device identity and replace user-based authentication on that machine.`
+The tag highlights the peer as AI GPU; it does not grant access.
+Your tailnet grants and optional Tailscale SSH policy still apply.
+
+Use tags only for dedicated server nodes. In Tailscale, tags become
+the device identity and replace user-based authentication.`
 }
 
 // InstallInstructions returns platform-specific install instructions.

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -98,9 +98,20 @@ func TestEnrollmentTagHelpMentionsAIGPUTag(t *testing.T) {
 	t.Parallel()
 
 	help := EnrollmentTagHelp()
-	for _, snippet := range []string{AIGPUTag, "tagOwners", "--advertise-tags=tag:ai-gpu"} {
+	for _, snippet := range []string{
+		AIGPUTag,
+		"tagOwners",
+		"you@example.com",
+		"tailscale login --advertise-tags=tag:ai-gpu",
+		"tailscale up --advertise-tags=tag:ai-gpu --force-reauth",
+		"does not grant access",
+		"replace user-based authentication",
+	} {
 		if !strings.Contains(help, snippet) {
 			t.Fatalf("expected help to contain %q", snippet)
 		}
+	}
+	if strings.Contains(help, "tailscale set --advertise-tags") {
+		t.Fatal("expected help to avoid the unsupported tailscale set --advertise-tags command")
 	}
 }

--- a/tests/firebase/firestore.rules.test.mjs
+++ b/tests/firebase/firestore.rules.test.mjs
@@ -179,6 +179,7 @@ const invalidEnvelopes = [
   ["short salt", { ...validEnvelope, salt: "A".repeat(21) }],
   ["long salt", { ...validEnvelope, salt: "A".repeat(23) }],
   ["padded salt", { ...validEnvelope, salt: `${"A".repeat(21)}=` }],
+  ["noncanonical salt", { ...validEnvelope, salt: `${"A".repeat(21)}B` }],
   ["URL-safe salt", { ...validEnvelope, salt: `${"A".repeat(21)}-` }],
   ["whitespace salt", { ...validEnvelope, salt: `${"A".repeat(21)} ` }],
   ["Unicode salt", { ...validEnvelope, salt: `${"A".repeat(21)}é` }],
@@ -194,6 +195,8 @@ const invalidEnvelopes = [
   ["empty ciphertext", { ...validEnvelope, ciphertext: "" }],
   ["cryptographically short ciphertext", { ...validEnvelope, ciphertext: "A".repeat(55) }],
   ["invalid raw-base64 length", { ...validEnvelope, ciphertext: "A".repeat(57) }],
+  ["noncanonical two-byte-tail ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(57)}B` }],
+  ["noncanonical one-byte-tail ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(58)}B` }],
   ["oversized ciphertext", { ...validEnvelope, ciphertext: "A".repeat(900001) }],
   ["padded ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(55)}=` }],
   ["URL-safe ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(55)}-` }],
@@ -219,6 +222,16 @@ for (const ciphertextLength of [56, 900000]) {
   test(`ciphertext boundary ${ciphertextLength} is accepted`, async () => {
     const owner = testEnvironment.authenticatedContext("owner-user").firestore()
     const value = { ...validEnvelope, ciphertext: "A".repeat(ciphertextLength) }
+
+    await assertSucceeds(setDoc(configDoc(owner), value))
+    assert.deepEqual(await storedConfig(), value)
+  })
+}
+
+for (const ciphertext of [`${"A".repeat(57)}Q`, `${"A".repeat(58)}E`]) {
+  test(`canonical unpadded ciphertext length ${ciphertext.length} is accepted`, async () => {
+    const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+    const value = { ...validEnvelope, ciphertext }
 
     await assertSucceeds(setDoc(configDoc(owner), value))
     assert.deepEqual(await storedConfig(), value)

--- a/tests/firebase/firestore.rules.test.mjs
+++ b/tests/firebase/firestore.rules.test.mjs
@@ -8,17 +8,34 @@ import {
   assertSucceeds,
   initializeTestEnvironment,
 } from "@firebase/rules-unit-testing"
-import { deleteDoc, doc, getDoc, setDoc } from "firebase/firestore"
+import {
+  collection,
+  deleteDoc,
+  doc,
+  documentId,
+  getCountFromServer,
+  getDoc,
+  getDocs,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore"
 
 const projectId = "demo-yokai"
 const rulesPath = fileURLToPath(new URL("../../firestore.rules", import.meta.url))
+const emulatorAddress = process.env.FIRESTORE_EMULATOR_HOST ?? "127.0.0.1:8088"
+const separator = emulatorAddress.lastIndexOf(":")
+const emulatorHost = emulatorAddress.slice(0, separator)
+const emulatorPort = Number(emulatorAddress.slice(separator + 1))
+
 const validEnvelope = {
   version: 1,
   cipher: "aes-256-gcm",
   kdf: "argon2id-3-65536-4",
-  salt: "AAAAAAAAAAAAAAAAAAAAAA",
-  nonce: "AAAAAAAAAAAAAAAA",
-  ciphertext: "encrypted-device-config",
+  salt: "A".repeat(22),
+  nonce: "A".repeat(16),
+  ciphertext: "A".repeat(56),
 }
 
 let testEnvironment
@@ -28,8 +45,8 @@ before(async () => {
     projectId,
     firestore: {
       rules: readFileSync(rulesPath, "utf8"),
-      host: "127.0.0.1",
-      port: 8080,
+      host: emulatorHost,
+      port: emulatorPort,
     },
   })
 })
@@ -42,45 +59,168 @@ after(async () => {
   await testEnvironment.cleanup()
 })
 
-test("an authenticated user can create, read, and delete their encrypted config", async () => {
-  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
-  const config = doc(owner, "device_configs", "owner-user")
+function configDoc(firestore, userId = "owner-user") {
+  return doc(firestore, "device_configs", userId)
+}
 
-  await assertSucceeds(setDoc(config, validEnvelope))
-  const snapshot = await assertSucceeds(getDoc(config))
-  assert.equal(snapshot.data().cipher, "aes-256-gcm")
-  await assertSucceeds(deleteDoc(config))
+async function seedConfig(userId = "owner-user", value = validEnvelope) {
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    await setDoc(configDoc(context.firestore(), userId), value)
+  })
+}
+
+async function storedConfig(userId = "owner-user") {
+  let result
+  await testEnvironment.withSecurityRulesDisabled(async (context) => {
+    const snapshot = await getDoc(configDoc(context.firestore(), userId))
+    result = snapshot.exists() ? snapshot.data() : null
+  })
+  return result
+}
+
+function withoutField(field) {
+  const value = { ...validEnvelope }
+  delete value[field]
+  return value
+}
+
+test("owner can create, get, update, and delete an encrypted config", async () => {
+  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+  const target = configDoc(owner)
+
+  await assertSucceeds(setDoc(target, validEnvelope))
+  const created = await assertSucceeds(getDoc(target))
+  assert.deepEqual(created.data(), validEnvelope)
+
+  const nextCiphertext = "B".repeat(56)
+  await assertSucceeds(updateDoc(target, { ciphertext: nextCiphertext }))
+  const updated = await assertSucceeds(getDoc(target))
+  assert.equal(updated.data().ciphertext, nextCiphertext)
+
+  await assertSucceeds(deleteDoc(target))
+  assert.equal(await storedConfig(), null)
 })
 
-test("another user cannot read, overwrite, or delete an owner's config", async () => {
-  const owner = testEnvironment.authenticatedContext("owner-user").firestore()
-  await assertSucceeds(setDoc(doc(owner, "device_configs", "owner-user"), validEnvelope))
-
+test("another user cannot create, read, overwrite, update, or delete owner data", async () => {
+  await seedConfig()
   const intruder = testEnvironment.authenticatedContext("intruder-user").firestore()
-  const target = doc(intruder, "device_configs", "owner-user")
+  const target = configDoc(intruder)
+
   await assertFails(getDoc(target))
   await assertFails(setDoc(target, validEnvelope))
+  await assertFails(updateDoc(target, { ciphertext: "B".repeat(56) }))
   await assertFails(deleteDoc(target))
+  await assertFails(setDoc(configDoc(intruder, "absent-user"), validEnvelope))
+
+  assert.deepEqual(await storedConfig(), validEnvelope)
+  assert.equal(await storedConfig("absent-user"), null)
 })
 
-test("unauthenticated clients cannot access cloud configs", async () => {
+test("unauthenticated clients cannot create, read, update, or delete configs", async () => {
+  await seedConfig()
   const anonymous = testEnvironment.unauthenticatedContext().firestore()
-  const target = doc(anonymous, "device_configs", "owner-user")
+  const target = configDoc(anonymous)
+
   await assertFails(getDoc(target))
-  await assertFails(setDoc(target, validEnvelope))
+  await assertFails(setDoc(configDoc(anonymous, "absent-user"), validEnvelope))
+  await assertFails(updateDoc(target, { ciphertext: "B".repeat(56) }))
+  await assertFails(deleteDoc(target))
+
+  assert.deepEqual(await storedConfig(), validEnvelope)
+  assert.equal(await storedConfig("absent-user"), null)
 })
 
-test("rules reject plaintext, unexpected fields, and oversized ciphertext", async () => {
+test("collection lists, constrained queries, and aggregations are denied", async () => {
+  await seedConfig()
+  for (const userId of ["owner-user", "intruder-user"]) {
+    const firestore = testEnvironment.authenticatedContext(userId).firestore()
+    const configs = collection(firestore, "device_configs")
+    await assertFails(getDocs(configs))
+    await assertFails(getDocs(query(configs, where(documentId(), "==", "owner-user"))))
+    await assertFails(getCountFromServer(configs))
+  }
+})
+
+test("device config subcollections remain inaccessible", async () => {
+  await seedConfig()
   const owner = testEnvironment.authenticatedContext("owner-user").firestore()
-  const target = doc(owner, "device_configs", "owner-user")
+  const child = doc(owner, "device_configs", "owner-user", "private", "child")
 
-  await assertFails(setDoc(target, { ...validEnvelope, cipher: "plaintext" }))
-  await assertFails(setDoc(target, { ...validEnvelope, email: "leak@example.com" }))
-  await assertFails(setDoc(target, { ...validEnvelope, ciphertext: "A".repeat(900001) }))
+  await assertFails(setDoc(child, { value: "not allowed" }))
+  await assertFails(getDoc(child))
 })
 
-test("an authenticated user cannot write outside their UID document", async () => {
+test("owner can delete a malformed legacy document", async () => {
+  await seedConfig("owner-user", { plaintext: "legacy" })
   const owner = testEnvironment.authenticatedContext("owner-user").firestore()
-  await assertFails(setDoc(doc(owner, "device_configs", "different-user"), validEnvelope))
-  await assertFails(setDoc(doc(owner, "other_collection", "owner-user"), validEnvelope))
+
+  await assertSucceeds(deleteDoc(configDoc(owner)))
+  assert.equal(await storedConfig(), null)
 })
+
+const invalidEnvelopes = [
+  ...["version", "cipher", "kdf", "salt", "nonce", "ciphertext"].map((field) => [
+    `missing ${field}`,
+    withoutField(field),
+  ]),
+  ["unexpected field", { ...validEnvelope, email: "leak@example.com" }],
+  ["string version", { ...validEnvelope, version: "1" }],
+  ["boolean version", { ...validEnvelope, version: true }],
+  ["fractional version", { ...validEnvelope, version: 1.5 }],
+  ["unsupported version", { ...validEnvelope, version: 2 }],
+  ["non-string cipher", { ...validEnvelope, cipher: 1 }],
+  ["empty cipher", { ...validEnvelope, cipher: "" }],
+  ["unsupported cipher", { ...validEnvelope, cipher: "plaintext" }],
+  ["non-string KDF", { ...validEnvelope, kdf: false }],
+  ["empty KDF", { ...validEnvelope, kdf: "" }],
+  ["unsupported KDF", { ...validEnvelope, kdf: "argon2id" }],
+  ["non-string salt", { ...validEnvelope, salt: 1 }],
+  ["empty salt", { ...validEnvelope, salt: "" }],
+  ["short salt", { ...validEnvelope, salt: "A".repeat(21) }],
+  ["long salt", { ...validEnvelope, salt: "A".repeat(23) }],
+  ["padded salt", { ...validEnvelope, salt: `${"A".repeat(21)}=` }],
+  ["URL-safe salt", { ...validEnvelope, salt: `${"A".repeat(21)}-` }],
+  ["whitespace salt", { ...validEnvelope, salt: `${"A".repeat(21)} ` }],
+  ["Unicode salt", { ...validEnvelope, salt: `${"A".repeat(21)}é` }],
+  ["non-string nonce", { ...validEnvelope, nonce: [] }],
+  ["empty nonce", { ...validEnvelope, nonce: "" }],
+  ["short nonce", { ...validEnvelope, nonce: "A".repeat(15) }],
+  ["long nonce", { ...validEnvelope, nonce: "A".repeat(17) }],
+  ["padded nonce", { ...validEnvelope, nonce: `${"A".repeat(15)}=` }],
+  ["URL-safe nonce", { ...validEnvelope, nonce: `${"A".repeat(15)}_` }],
+  ["whitespace nonce", { ...validEnvelope, nonce: `${"A".repeat(15)} ` }],
+  ["Unicode nonce", { ...validEnvelope, nonce: `${"A".repeat(15)}é` }],
+  ["non-string ciphertext", { ...validEnvelope, ciphertext: { value: "A" } }],
+  ["empty ciphertext", { ...validEnvelope, ciphertext: "" }],
+  ["cryptographically short ciphertext", { ...validEnvelope, ciphertext: "A".repeat(55) }],
+  ["invalid raw-base64 length", { ...validEnvelope, ciphertext: "A".repeat(57) }],
+  ["oversized ciphertext", { ...validEnvelope, ciphertext: "A".repeat(900001) }],
+  ["padded ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(55)}=` }],
+  ["URL-safe ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(55)}-` }],
+  ["whitespace ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(55)} ` }],
+  ["Unicode ciphertext", { ...validEnvelope, ciphertext: `${"A".repeat(55)}é` }],
+]
+
+for (const [name, invalidEnvelope] of invalidEnvelopes) {
+  test(`invalid ${name} create and update fail without changing state`, async () => {
+    const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+    const target = configDoc(owner)
+
+    await assertFails(setDoc(target, invalidEnvelope))
+    assert.equal(await storedConfig(), null)
+
+    await seedConfig()
+    await assertFails(setDoc(target, invalidEnvelope))
+    assert.deepEqual(await storedConfig(), validEnvelope)
+  })
+}
+
+for (const ciphertextLength of [56, 900000]) {
+  test(`ciphertext boundary ${ciphertextLength} is accepted`, async () => {
+    const owner = testEnvironment.authenticatedContext("owner-user").firestore()
+    const value = { ...validEnvelope, ciphertext: "A".repeat(ciphertextLength) }
+
+    await assertSucceeds(setDoc(configDoc(owner), value))
+    assert.deepEqual(await storedConfig(), value)
+  })
+}


### PR DESCRIPTION
## Summary

- reconcile the Tailscale GPU-node changes already on `main` back into the cloud-sync development line while preserving the full Firestore CI job
- require an exact, canonical encrypted-envelope schema in Firestore rules and in the Go client
- prevent concurrent first saves and replacements from silently overwriting newer backups by using Firestore document preconditions
- reject malformed, oversized, incomplete, or timestamp-less Firestore responses before they reach decryption or success output
- make macOS system-metric fallback values use the same numeric types as successful Linux reads

## Root cause

The original rules checked maximum lengths but did not fully validate the encrypted envelope, while the client accepted a broader response shape and performed unconditional PATCH requests. That left malformed-envelope and lost-update gaps, and the five-case emulator suite did not prove that rejected mutations preserved the prior document.

## Impact

Cloud backups remain client-side encrypted, but malformed writes and collection queries are now denied, rejected writes are proven not to change state, and a stale computer must reread and explicitly retry instead of overwriting a newer backup. Existing owners can still delete malformed legacy documents.

## Validation

- `go test -race -coverprofile=... ./...` on Go 1.25
- `go vet ./...`
- `make lint` (0 issues)
- Firestore emulator rules suite: 55/55
- OpenTUI tests: 26/26, plus bundle and standalone compile
- Firebase provisioning safeguards, Bash syntax, ShellCheck, Actionlint, and clean diff checks
- GoReleaser snapshot: five platform archives; every archive contains both binaries
- independent security review and follow-up: all findings resolved, clean approval

## Promotion note

This PR targets `develop`. It does not deploy production rules or touch credentials, billing, IAM, or user data. Before production promotion, run one real staging Firestore create-race/update-race smoke test in addition to the mocked concurrency coverage here.
